### PR TITLE
feat(employees): add PAN number format validation

### DIFF
--- a/packages/client/src/pages/employees/EmployeeDetailPage.tsx
+++ b/packages/client/src/pages/employees/EmployeeDetailPage.tsx
@@ -634,6 +634,12 @@ export function EmployeeDetailPage() {
                 label="PAN"
                 defaultValue={taxInfo.pan || ""}
                 placeholder="ABCDE1234F"
+                maxLength={10}
+                pattern="[A-Z]{5}[0-9]{4}[A-Z]{1}"
+                title="PAN must be 10 characters: 5 letters, 4 digits, 1 letter (e.g., ABCDE1234F)"
+                onChange={(e) => {
+                  e.currentTarget.value = e.currentTarget.value.toUpperCase();
+                }}
               />
               <SelectField
                 id="regime"


### PR DESCRIPTION
## Summary
- Adds client-side validation for Indian PAN on the Statutory edit modal in the employee detail page.
- Pattern: `[A-Z]{5}[0-9]{4}[A-Z]{1}` (5 letters, 4 digits, 1 letter, e.g. `ABCDE1234F`).
- Auto-uppercases input as the user types.
- Enforces 10-character `maxLength`.
- Empty PAN still passes (field remains optional).

## Test plan
- [ ] Open an employee then Statutory then Edit.
- [ ] Try saving with `125214124214` and confirm browser blocks submission.
- [ ] Try saving with `abcde1234f` and confirm field auto-uppercases and saves.
- [ ] Clearing the PAN field still saves successfully.