### PR TITLE
fix(employees): return snake_case from /employees/search so result clicks work

### DIFF
--- a/packages/server/src/services/employee.service.ts
+++ b/packages/server/src/services/employee.service.ts
@@ -179,17 +179,21 @@ export class EmployeeService {
       .orderBy("first_name")
       .limit(limit);
 
-    // Enrich with department names
+    // Enrich with department names. Returns snake_case to match the rest of
+    // the employee API shape — the header search bar navigates on `emp.id`
+    // and displays `emp.first_name` / `emp.last_name` etc, so camelCase here
+    // was landing users on /employees/undefined (issue #23).
     const results = await Promise.all(
       rows.map(async (r: any) => ({
-        empcloudUserId: r.id,
-        empCode: r.emp_code,
-        firstName: r.first_name,
-        lastName: r.last_name,
+        id: r.id,
+        emp_code: r.emp_code,
+        employee_code: r.emp_code, // some UIs still read this legacy key
+        first_name: r.first_name,
+        last_name: r.last_name,
         email: r.email,
         designation: r.designation,
         department: await getUserDepartmentName(r.department_id),
-        isActive: r.status === 1,
+        is_active: r.status === 1,
       })),
     );
 


### PR DESCRIPTION
Fixes #23.

## Root cause
Clicking an employee from the header search bar redirected to `/employees/undefined`. The `EmployeeService.search()` method in [packages/server/src/services/employee.service.ts](packages/server/src/services/employee.service.ts) was the only employee endpoint that returned **camelCase** keys:

```json
{ "empcloudUserId": 42, "empCode": "EMP001", "firstName": "Priya", "lastName": "Patel", ... }
```

but the header in [DashboardLayout.tsx](packages/client/src/components/layout/DashboardLayout.tsx) — and every other screen that consumes employee records — reads **snake_case**:

```tsx
onClick={() => navigate(`/employees/${emp.id}`)}     // undefined
{emp.first_name} {emp.last_name}                      // undefined undefined
{emp.employee_code} · {emp.department}                // undefined · Finance
```

So `emp.id` was `undefined`, `navigate()` landed on `/employees/undefined`, and the result row displayed `undefined undefined`.

## Fix
Normalised the search output to the same shape every other employee endpoint already uses:

```ts
{
  id,
  emp_code,
  employee_code, // legacy alias some UIs still read
  first_name,
  last_name,
  email,
  designation,
  department,
  is_active,
}
```

Server-side only — no frontend changes. The existing `navigate(\`/employees/${emp.id}\`)` now receives the real id.

## Test plan
- [x] Header search bar: type a name → suggestion shows *full name* (not "undefined undefined").
- [x] Click a result → lands on `/employees/<real-id>` and the detail page loads.
- [x] Fallback path (when `/employees/search` 5xx's) still works — the `/employees?limit=100` list endpoint already returned snake_case, so the fallback filter was fine before and stays fine.
- [x] `emp_code` / `employee_code` both present — any screen that imports the result object keeps rendering the employee code regardless of which field name it uses.
- [x] `npx tsc --noEmit` on `packages/server` passes.