### PR TITLE
fix(employees): reject future/missing DOB in CSV import

### DIFF
--- a/packages/server/src/api/routes/employee.routes.ts
+++ b/packages/server/src/api/routes/employee.routes.ts
@@ -178,8 +178,7 @@ router.post(
       if (!emp.lastName) emp.lastName = emp["Last Name"] || emp.last_name || "";
       if (!emp.email) emp.email = emp["Email"] || "";
       if (!emp.phone) emp.phone = emp["Phone"] || emp.contact_number || "";
-      if (!emp.dateOfBirth)
-        emp.dateOfBirth = emp["Date of Birth"] || emp.date_of_birth || "1990-01-01";
+      if (!emp.dateOfBirth) emp.dateOfBirth = emp["Date of Birth"] || emp.date_of_birth || "";
       if (!emp.gender) emp.gender = (emp["Gender"] || "other").toLowerCase();
       if (!emp.dateOfJoining)
         emp.dateOfJoining =
@@ -196,6 +195,31 @@ router.post(
             email: emp.email || "—",
             status: "error",
             error: "Missing required fields (email, firstName, lastName)",
+          });
+          continue;
+        }
+        // DOB must be present AND strictly in the past — issue #21 / #8.
+        // Previously this path silently defaulted to "1990-01-01" which
+        // let rows with a future or missing DOB sneak through and then
+        // become hard to spot in the directory.
+        if (!emp.dateOfBirth) {
+          results.push({
+            row: i + 1,
+            email: emp.email,
+            status: "error",
+            error: "Date of birth is required",
+          });
+          continue;
+        }
+        const dob = new Date(emp.dateOfBirth);
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        if (Number.isNaN(dob.getTime()) || dob.getTime() >= today.getTime()) {
+          results.push({
+            row: i + 1,
+            email: emp.email,
+            status: "error",
+            error: "Date of birth must be a valid past date",
           });
           continue;
         }


### PR DESCRIPTION
Closes #21. Closes #8. (Both report the same bug.)

## Root cause
Three places accept a new employee's date of birth. Two were already locked down:

| Path | DOB validation |
|---|---|
| `POST /employees` (Add Employee form) | `createEmployeeSchema.pastDateOfBirth` — rejects future / today / invalid |
| Browser form | `<input max={todayISO()}>` + explicit `handleSubmit` check that toasts "Date of birth must be in the past" |
| **`POST /employees/import` (CSV bulk import)** | **no validation — silently defaulted missing DOB to `"1990-01-01"`** |

So a CSV row with `2030-05-01` for DOB (or no DOB at all) sailed straight through. Once inserted, nothing flagged it — the employee just showed up in the directory with a nonsense birthday.

## Fix
In [`packages/server/src/api/routes/employee.routes.ts`](packages/server/src/api/routes/employee.routes.ts) inside the per-row import loop:

1. **Dropped the `"1990-01-01"` fallback.** A missing DOB now fails the row cleanly with `"Date of birth is required"` instead of being silently patched.
2. **Added a past-date check** mirroring `pastDateOfBirth` in the Zod schema (parse → compare against midnight today). Invalid rows get `"Date of birth must be a valid past date"` in the response's `results[]` array.

The import UI already renders `results[].error` next to each row, so no frontend change is needed — the new errors surface automatically.

Frontend + `POST /employees` paths were already correct and stay unchanged.

## Test plan
- [x] CSV row with `dateOfBirth: 2030-06-01` → rejected with `Date of birth must be a valid past date`, no row inserted.
- [x] CSV row with empty DOB → rejected with `Date of birth is required` (was silently using 1990-01-01 before).
- [x] CSV row with valid past DOB → imported successfully.
- [x] Add Employee form already blocked future DOB at three layers (input `max`, `handleSubmit` toast, `pastDateOfBirth` Zod). Regression-checked — still works.
- [x] `pnpm --filter @emp-payroll/server exec tsc --noEmit` passes.