### PR TITLE
fix(employees): reject numeric bank names on self-service + global payroll paths

### DIFF
--- a/packages/server/src/api/routes/self-service.routes.ts
+++ b/packages/server/src/api/routes/self-service.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authenticate } from "../middleware/auth.middleware";
 import { wrap, param } from "../helpers";
+import { validate, selfUpdateBankDetailsSchema, bankUpdateRequestSchema } from "../validators";
 import { EmployeeService } from "../../services/employee.service";
 import { SalaryService } from "../../services/salary.service";
 import { PayslipService } from "../../services/payslip.service";
@@ -198,6 +199,7 @@ router.get(
 
 router.put(
   "/profile/bank-details",
+  validate(selfUpdateBankDetailsSchema),
   wrap(async (req, res) => {
     const data = await empSvc.updateBankDetails(
       req.user!.empcloudUserId,
@@ -214,6 +216,7 @@ const bankReqSvc = new BankUpdateRequestService();
 
 router.post(
   "/bank-update-request",
+  validate(bankUpdateRequestSchema),
   wrap(async (req, res) => {
     const data = await bankReqSvc.submit(req.user!.empcloudUserId, req.user!.empcloudOrgId, {
       currentDetails: req.body.currentDetails,

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -125,6 +125,43 @@ export const updateBankDetailsSchema = z.object({
   }),
 });
 
+// Same body as updateBankDetailsSchema but without the :id param — used by
+// the self-service route where the user is always operating on their own
+// profile. Having a dedicated schema lets the self-service route enforce
+// the same bank-name regex check that the HR route does.
+export const selfUpdateBankDetailsSchema = z.object({
+  body: z.object({
+    bankName: bankNameSchema,
+    accountNumber: z.string().min(1).max(50),
+    ifscCode: z.string().min(1).max(20),
+    accountType: z.enum(["savings", "current", "salary"]).optional(),
+    branchName: z.string().max(100).optional(),
+  }),
+});
+
+// Employee-submitted change request. currentDetails is read-only context;
+// only requestedDetails needs strict validation since that's what would be
+// applied if approved.
+export const bankUpdateRequestSchema = z.object({
+  body: z.object({
+    currentDetails: z
+      .object({
+        bankName: z.string().optional(),
+        accountNumber: z.string().optional(),
+        ifscCode: z.string().optional(),
+      })
+      .optional(),
+    requestedDetails: z.object({
+      bankName: bankNameSchema,
+      accountNumber: z.string().min(1).max(50),
+      ifscCode: z.string().min(1).max(20),
+      accountType: z.enum(["savings", "current", "salary"]).optional(),
+      branchName: z.string().max(100).optional(),
+    }),
+    reason: z.string().max(500).optional(),
+  }),
+});
+
 export const updateEmployeeSchema = z.object({
   params: z.object({ id: z.string() }),
   body: z.object({
@@ -452,7 +489,7 @@ export const addGlobalEmployeeSchema = z.object({
     salaryFrequency: z.enum(["monthly", "biweekly", "weekly", "annual"]).default("monthly"),
     empcloudUserId: z.union([z.string(), z.number()]).optional(),
     taxId: z.string().max(50).optional(),
-    bankName: z.string().max(100).optional(),
+    bankName: bankNameSchema.optional(),
     bankAccount: z.string().max(50).optional(),
     bankRouting: z.string().max(50).optional(),
     contractDocumentUrl: z.string().optional(),
@@ -478,7 +515,7 @@ export const updateGlobalEmployeeSchema = z.object({
     salaryFrequency: z.enum(["monthly", "biweekly", "weekly", "annual"]).optional(),
     status: z.enum(["active", "onboarding", "offboarding", "terminated"]).optional(),
     taxId: z.string().max(50).optional(),
-    bankName: z.string().max(100).optional(),
+    bankName: bankNameSchema.optional(),
     bankAccount: z.string().max(50).optional(),
     bankRouting: z.string().max(50).optional(),
     contractDocumentUrl: z.string().optional(),


### PR DESCRIPTION
Closes #20.

## Root cause
`bankNameSchema` — `^[\p{L}\s.,&-]+$` — already guards the Add Employee form (`createEmployeeSchema`) and HR's `PUT /employees/:id/bank-details` (`updateBankDetailsSchema`). But three paths accepted anything up to 100 chars, so a user could save `"123456"` as the bank name:

| Path | Old validation |
|---|---|
| Self-service `PUT /profile/bank-details` | **none** — body passed straight through |
| Self-service `POST /bank-update-request` | **none** — body passed straight through |
| Global payroll `createGlobalEmployeeSchema` / `updateGlobalEmployeeSchema` | `z.string().max(100).optional()` — no regex |

## Fix

### `validators/index.ts`
- New `selfUpdateBankDetailsSchema` (same body as `updateBankDetailsSchema`, no `:id` param since the self-service route always operates on the caller).
- New `bankUpdateRequestSchema` — validates `requestedDetails.bankName` with `bankNameSchema` and lets `currentDetails` stay permissive (it's read-only context).
- Swapped `bankName: z.string().max(100).optional()` → `bankName: bankNameSchema.optional()` in `createGlobalEmployeeSchema` and `updateGlobalEmployeeSchema`.

### `self-service.routes.ts`
Imported the two new schemas and wired them via `validate(...)` on `PUT /profile/bank-details` and `POST /bank-update-request`.

No frontend change — `EmployeeCreatePage` already runs the same regex in `handleSubmit`, and the self-service / global-payroll screens will now surface the server's Zod error message if a user types digits.

## Test plan
- [x] Self-service → Update Bank Details with `"Bank 1234"` → 400 with `"Bank name must only contain letters, spaces, and . , & -"` (was 200 before).
- [x] Self-service → Submit Bank Change Request with numeric `requestedDetails.bankName` → 400 (was 201 before).
- [x] Global payroll → Create / update employee with numeric `bankName` → 400 (was 200).
- [x] Legitimate bank names still accepted: `"State Bank of India"`, `"HDFC Bank"`, `"Crédit Agricole"`, `"J.P. Morgan Chase & Co."`.
- [x] `pnpm --filter @emp-payroll/server exec tsc --noEmit` passes.