### PR TITLE
fix(salary): persist components when editing a salary structure

### DIFF
--- a/packages/server/src/services/salary.service.ts
+++ b/packages/server/src/services/salary.service.ts
@@ -93,11 +93,45 @@ export class SalaryService {
 
   async updateStructure(id: string, orgId: string, data: any) {
     await this.getStructure(id, orgId);
-    return this.db.update("salary_structures", id, {
+
+    const updated = await this.db.update("salary_structures", id, {
       name: data.name,
       description: data.description,
       is_default: data.isDefault,
     });
+
+    // Reconcile components when the caller supplies the `components` array.
+    // The UI always posts the full current list, so the simplest correct
+    // behaviour is replace-all: soft-delete the existing active rows and
+    // insert the new list. Omitting this was the root of issues #19 / #9 —
+    // the structure itself saved (name/description) but any added, removed
+    // or edited preset rows silently disappeared after the toast.
+    if (Array.isArray(data.components)) {
+      const { data: existing } = await this.getComponents(id);
+      for (const c of existing) {
+        await this.db.update("salary_components", (c as any).id, { is_active: false });
+      }
+      for (let i = 0; i < data.components.length; i++) {
+        const c = data.components[i];
+        await this.db.create("salary_components", {
+          structure_id: id,
+          name: c.name,
+          code: c.code,
+          type: c.type,
+          calculation_type: c.calculationType,
+          value: c.value || 0,
+          percentage_of: c.percentageOf || null,
+          formula: c.formula || null,
+          is_taxable: c.isTaxable !== false,
+          is_statutory: c.isStatutory || false,
+          is_proratable: c.isProratable !== false,
+          is_active: true,
+          sort_order: c.sortOrder ?? i,
+        });
+      }
+    }
+
+    return updated;
   }
 
   async deleteStructure(id: string, orgId: string) {


### PR DESCRIPTION
Closes #19. Closes #9.

## Root cause
`SalaryService.updateStructure` only persisted the structure row's `name` / `description` / `is_default`. It **never looked at `data.components`**, even though [SalaryStructuresPage.tsx](packages/client/src/pages/payroll/SalaryStructuresPage.tsx#L141-L159) always posts the full component list on edit:

```ts
const payload = {
  name, description, isDefault: false,
  components: components.filter(...).map(...)
};
await apiPut(`/salary-structures/${editingStructure.id}`, payload);
```

Server returned 200, UI showed "Salary structure updated". On refresh the structure was still there — but any added / removed / edited preset rows were gone. That's exactly the scenario the screenshots in #9 show ("Added new preset, it shows successful message but its not getting saved").

The create path was fine — it iterates `data.components` and inserts. The edit path just never learned to.

## Fix
Replace-all reconciliation in `updateStructure`:

```ts
if (Array.isArray(data.components)) {
  // soft-delete every existing active component for this structure
  for (const c of existing) {
    await this.db.update("salary_components", c.id, { is_active: false });
  }
  // insert the new list as fresh rows (same shape createStructure uses)
  for (let i = 0; i < data.components.length; i++) {
    await this.db.create("salary_components", { /* ... */ is_active: true });
  }
}
```

- **Array.isArray-gated** so name-only updates (no `components` in payload) still work unchanged.
- **Soft delete** (rather than hard) preserves history for audit.
- **Same shape** as `createStructure` — keeps both paths writing the same fields so there's no drift.

No frontend change required.

## Test plan
- [x] Edit an existing structure → add a new preset component → Save → refresh → new row still there.
- [x] Edit → change an existing component's `value` or `code` → refresh → change persists.
- [x] Edit → remove a component from the UI list → refresh → component is gone from the structure.
- [x] Edit and change only the name (no `components` in payload) → structure name updates, existing components unchanged.
- [x] Create flow regression — still works the same.
- [x] `pnpm --filter @emp-payroll/server exec tsc --noEmit` passes.