### PR TITLE
fix(benefits): add Edit/Delete on plans + reject end-date < start-date

### DIFF
--- a/packages/client/src/pages/benchmarks/BenchmarksPage.tsx
+++ b/packages/client/src/pages/benchmarks/BenchmarksPage.tsx
@@ -8,7 +8,7 @@ import { Modal } from "@/components/ui/Modal";
 import { DataTable } from "@/components/ui/DataTable";
 import { StatCard } from "@/components/ui/StatCard";
 import { formatCurrency, formatDate } from "@/lib/utils";
-import { apiGet, apiPost, apiDelete } from "@/api/client";
+import { apiGet, apiPost, apiPut, apiDelete } from "@/api/client";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Plus,
@@ -19,6 +19,7 @@ import {
   Minus,
   Loader2,
   Trash2,
+  Pencil,
   FileUp,
 } from "lucide-react";
 import toast from "react-hot-toast";
@@ -27,6 +28,9 @@ export function BenchmarksPage() {
   const [tab, setTab] = useState<"benchmarks" | "compa-ratio">("benchmarks");
   const [showCreate, setShowCreate] = useState(false);
   const [creating, setCreating] = useState(false);
+  // When set, the create modal re-purposes itself as an edit form pre-filled
+  // with this row's values (issue #18 — edit button was missing entirely).
+  const [editing, setEditing] = useState<any>(null);
   const qc = useQueryClient();
 
   const { data: benchRes, isLoading: benchLoading } = useQuery({
@@ -44,23 +48,34 @@ export function BenchmarksPage() {
   const compaData = compaRes?.data || {};
   const compaEmployees = compaData.employees || [];
 
-  async function handleCreate(e: React.FormEvent<HTMLFormElement>) {
+  function closeModal() {
+    setShowCreate(false);
+    setEditing(null);
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setCreating(true);
     const fd = new FormData(e.currentTarget);
+    const payload = {
+      jobTitle: fd.get("jobTitle"),
+      department: fd.get("department"),
+      location: fd.get("location"),
+      marketP25: Number(fd.get("marketP25")),
+      marketP50: Number(fd.get("marketP50")),
+      marketP75: Number(fd.get("marketP75")),
+      source: fd.get("source"),
+      effectiveDate: fd.get("effectiveDate"),
+    };
     try {
-      await apiPost("/benchmarks", {
-        jobTitle: fd.get("jobTitle"),
-        department: fd.get("department"),
-        location: fd.get("location"),
-        marketP25: Number(fd.get("marketP25")),
-        marketP50: Number(fd.get("marketP50")),
-        marketP75: Number(fd.get("marketP75")),
-        source: fd.get("source"),
-        effectiveDate: fd.get("effectiveDate"),
-      });
-      toast.success("Benchmark created");
-      setShowCreate(false);
+      if (editing) {
+        await apiPut(`/benchmarks/${editing.id}`, payload);
+        toast.success("Benchmark updated");
+      } else {
+        await apiPost("/benchmarks", payload);
+        toast.success("Benchmark created");
+      }
+      closeModal();
       qc.invalidateQueries({ queryKey: ["benchmarks"] });
     } catch (err: any) {
       toast.error(err.response?.data?.error?.message || "Failed");
@@ -108,14 +123,28 @@ export function BenchmarksPage() {
       key: "actions",
       header: "",
       render: (r: any) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => deleteBenchmark(r.id)}
-          className="text-red-600"
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            title="Edit"
+            onClick={() => {
+              setEditing(r);
+              setShowCreate(true);
+            }}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            title="Delete"
+            onClick={() => deleteBenchmark(r.id)}
+            className="text-red-600"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
       ),
     },
   ];
@@ -283,34 +312,91 @@ export function BenchmarksPage() {
         </>
       )}
 
-      {/* Create Benchmark Modal */}
+      {/* Create / Edit Benchmark Modal — same form re-purposed as edit when
+          `editing` is set. Issue #17: the P25/P50/P75 inputs now carry
+          min=0 so the stepper can't decrement into negative salary values.
+          Issue #18: the Edit button that populates `editing` and opens
+          this modal was previously missing. */}
       <Modal
         open={showCreate}
-        onClose={() => setShowCreate(false)}
-        title="Add Compensation Benchmark"
+        onClose={closeModal}
+        title={editing ? "Edit Compensation Benchmark" : "Add Compensation Benchmark"}
       >
-        <form onSubmit={handleCreate} className="space-y-4">
-          <Input label="Job Title" name="jobTitle" placeholder="e.g., Software Engineer" required />
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            label="Job Title"
+            name="jobTitle"
+            placeholder="e.g., Software Engineer"
+            defaultValue={editing?.job_title || ""}
+            required
+          />
           <div className="grid grid-cols-2 gap-4">
-            <Input label="Department" name="department" placeholder="e.g., Engineering" />
-            <Input label="Location" name="location" placeholder="e.g., Bangalore" />
+            <Input
+              label="Department"
+              name="department"
+              placeholder="e.g., Engineering"
+              defaultValue={editing?.department || ""}
+            />
+            <Input
+              label="Location"
+              name="location"
+              placeholder="e.g., Bangalore"
+              defaultValue={editing?.location || ""}
+            />
           </div>
           <div className="grid grid-cols-3 gap-4">
-            <Input label="P25 (Annual)" name="marketP25" type="number" required />
-            <Input label="P50 Median (Annual)" name="marketP50" type="number" required />
-            <Input label="P75 (Annual)" name="marketP75" type="number" required />
+            <Input
+              label="P25 (Annual)"
+              name="marketP25"
+              type="number"
+              min={0}
+              step="any"
+              defaultValue={editing?.market_p25 ?? ""}
+              required
+            />
+            <Input
+              label="P50 Median (Annual)"
+              name="marketP50"
+              type="number"
+              min={0}
+              step="any"
+              defaultValue={editing?.market_p50 ?? ""}
+              required
+            />
+            <Input
+              label="P75 (Annual)"
+              name="marketP75"
+              type="number"
+              min={0}
+              step="any"
+              defaultValue={editing?.market_p75 ?? ""}
+              required
+            />
           </div>
           <div className="grid grid-cols-2 gap-4">
-            <Input label="Source" name="source" placeholder="e.g., Glassdoor 2026" />
-            <Input label="Effective Date" name="effectiveDate" type="date" required />
+            <Input
+              label="Source"
+              name="source"
+              placeholder="e.g., Glassdoor 2026"
+              defaultValue={editing?.source || ""}
+            />
+            <Input
+              label="Effective Date"
+              name="effectiveDate"
+              type="date"
+              defaultValue={
+                editing?.effective_date ? String(editing.effective_date).slice(0, 10) : ""
+              }
+              required
+            />
           </div>
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={() => setShowCreate(false)}>
+            <Button type="button" variant="ghost" onClick={closeModal}>
               Cancel
             </Button>
             <Button type="submit" disabled={creating}>
               {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Save Benchmark
+              {editing ? "Update Benchmark" : "Save Benchmark"}
             </Button>
           </div>
         </form>

--- a/packages/client/src/pages/benefits/BenefitsPage.tsx
+++ b/packages/client/src/pages/benefits/BenefitsPage.tsx
@@ -9,10 +9,20 @@ import { Modal } from "@/components/ui/Modal";
 import { DataTable } from "@/components/ui/DataTable";
 import { StatCard } from "@/components/ui/StatCard";
 import { formatCurrency } from "@/lib/utils";
-import { apiGet, apiPost, apiPut } from "@/api/client";
+import { apiGet, apiPost, apiPut, apiDelete } from "@/api/client";
 import { useEmployees } from "@/api/hooks";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plus, Heart, Shield, Users, DollarSign, UserPlus, Loader2 } from "lucide-react";
+import {
+  Plus,
+  Heart,
+  Shield,
+  Users,
+  DollarSign,
+  UserPlus,
+  Loader2,
+  Pencil,
+  Trash2,
+} from "lucide-react";
 import toast from "react-hot-toast";
 
 const PLAN_TYPES = [
@@ -35,6 +45,8 @@ export function BenefitsPage() {
   const [showCreatePlan, setShowCreatePlan] = useState(false);
   const [showEnroll, setShowEnroll] = useState(false);
   const [creating, setCreating] = useState(false);
+  // When set, the plan modal re-purposes as edit (#16).
+  const [editingPlan, setEditingPlan] = useState<any>(null);
   const qc = useQueryClient();
   const { data: empRes } = useEmployees({ limit: 200 });
 
@@ -58,29 +70,59 @@ export function BenefitsPage() {
   const enrollments = enrollRes?.data || [];
   const employees = empRes?.data?.data || [];
 
-  async function handleCreatePlan(e: React.FormEvent<HTMLFormElement>) {
+  function closePlanModal() {
+    setShowCreatePlan(false);
+    setEditingPlan(null);
+  }
+
+  async function handlePlanSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setCreating(true);
     const fd = new FormData(e.currentTarget);
+    const start = String(fd.get("enrollmentPeriodStart") || "");
+    const end = String(fd.get("enrollmentPeriodEnd") || "");
+    // Client-side guard for #15 — server also rejects, but we fail fast.
+    if (start && end && new Date(end).getTime() < new Date(start).getTime()) {
+      toast.error("Enrollment end date cannot be before start date");
+      return;
+    }
+    setCreating(true);
+    const payload = {
+      name: fd.get("name"),
+      type: fd.get("type"),
+      provider: fd.get("provider"),
+      description: fd.get("description"),
+      premiumAmount: Number(fd.get("premiumAmount") || 0),
+      employerContribution: Number(fd.get("employerContribution") || 0),
+      enrollmentPeriodStart: start || undefined,
+      enrollmentPeriodEnd: end || undefined,
+    };
     try {
-      await apiPost("/benefits/plans", {
-        name: fd.get("name"),
-        type: fd.get("type"),
-        provider: fd.get("provider"),
-        description: fd.get("description"),
-        premiumAmount: Number(fd.get("premiumAmount") || 0),
-        employerContribution: Number(fd.get("employerContribution") || 0),
-        enrollmentPeriodStart: fd.get("enrollmentPeriodStart") || undefined,
-        enrollmentPeriodEnd: fd.get("enrollmentPeriodEnd") || undefined,
-      });
-      toast.success("Benefit plan created");
-      setShowCreatePlan(false);
+      if (editingPlan) {
+        await apiPut(`/benefits/plans/${editingPlan.id}`, payload);
+        toast.success("Benefit plan updated");
+      } else {
+        await apiPost("/benefits/plans", payload);
+        toast.success("Benefit plan created");
+      }
+      closePlanModal();
       qc.invalidateQueries({ queryKey: ["benefit-plans"] });
       qc.invalidateQueries({ queryKey: ["benefits-dashboard"] });
     } catch (err: any) {
-      toast.error(err.response?.data?.error?.message || "Failed to create plan");
+      toast.error(err.response?.data?.error?.message || "Failed to save plan");
     } finally {
       setCreating(false);
+    }
+  }
+
+  async function deletePlan(id: string) {
+    if (!confirm("Deactivate this benefit plan? Existing enrollments are unaffected.")) return;
+    try {
+      await apiDelete(`/benefits/plans/${id}`);
+      toast.success("Benefit plan deactivated");
+      qc.invalidateQueries({ queryKey: ["benefit-plans"] });
+      qc.invalidateQueries({ queryKey: ["benefits-dashboard"] });
+    } catch (err: any) {
+      toast.error(err.response?.data?.error?.message || "Failed to deactivate plan");
     }
   }
 
@@ -149,6 +191,36 @@ export function BenefitsPage() {
         <Badge variant={r.is_active ? "active" : "inactive"}>
           {r.is_active ? "Active" : "Inactive"}
         </Badge>
+      ),
+    },
+    {
+      key: "actions",
+      header: "",
+      render: (r: any) => (
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            title="Edit"
+            onClick={() => {
+              setEditingPlan(r);
+              setShowCreatePlan(true);
+            }}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+          {r.is_active && (
+            <Button
+              variant="ghost"
+              size="sm"
+              title="Deactivate"
+              onClick={() => deletePlan(r.id)}
+              className="text-red-600"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
       ),
     },
   ];
@@ -293,37 +365,84 @@ export function BenefitsPage() {
         </Card>
       )}
 
-      {/* Create Plan Modal */}
+      {/* Create / Edit Plan Modal — one form for both flows (#16). */}
       <Modal
         open={showCreatePlan}
-        onClose={() => setShowCreatePlan(false)}
-        title="Create Benefit Plan"
+        onClose={closePlanModal}
+        title={editingPlan ? "Edit Benefit Plan" : "Create Benefit Plan"}
+        key={editingPlan?.id || "new-plan"}
       >
-        <form onSubmit={handleCreatePlan} className="space-y-4">
-          <Input label="Plan Name" name="name" required />
-          <SelectField label="Type" name="type" options={PLAN_TYPES} required />
-          <Input label="Provider" name="provider" />
-          <Input label="Description" name="description" />
+        <form onSubmit={handlePlanSubmit} className="space-y-4">
+          <Input label="Plan Name" name="name" defaultValue={editingPlan?.name || ""} required />
+          <SelectField
+            label="Type"
+            name="type"
+            options={PLAN_TYPES}
+            defaultValue={editingPlan?.type || ""}
+            required
+          />
+          <Input label="Provider" name="provider" defaultValue={editingPlan?.provider || ""} />
+          <Input
+            label="Description"
+            name="description"
+            defaultValue={editingPlan?.description || ""}
+          />
           <div className="grid grid-cols-2 gap-4">
-            <Input label="Monthly Premium" name="premiumAmount" type="number" step="0.01" />
+            <Input
+              label="Monthly Premium"
+              name="premiumAmount"
+              type="number"
+              step="0.01"
+              min={0}
+              defaultValue={editingPlan?.premium_amount ?? ""}
+            />
             <Input
               label="Employer Contribution"
               name="employerContribution"
               type="number"
               step="0.01"
+              min={0}
+              defaultValue={editingPlan?.employer_contribution ?? ""}
             />
           </div>
           <div className="grid grid-cols-2 gap-4">
-            <Input label="Enrollment Start" name="enrollmentPeriodStart" type="date" />
-            <Input label="Enrollment End" name="enrollmentPeriodEnd" type="date" />
+            <Input
+              label="Enrollment Start"
+              name="enrollmentPeriodStart"
+              type="date"
+              defaultValue={
+                editingPlan?.enrollment_period_start
+                  ? String(editingPlan.enrollment_period_start).slice(0, 10)
+                  : ""
+              }
+              onChange={(e) => {
+                // Push the selected start date as the minimum for the end date input,
+                // so the browser's date picker blocks earlier selections (#15).
+                const form = (e.currentTarget as HTMLInputElement).form;
+                const endInput = form?.elements.namedItem(
+                  "enrollmentPeriodEnd",
+                ) as HTMLInputElement | null;
+                if (endInput) endInput.min = e.currentTarget.value;
+              }}
+            />
+            <Input
+              label="Enrollment End"
+              name="enrollmentPeriodEnd"
+              type="date"
+              defaultValue={
+                editingPlan?.enrollment_period_end
+                  ? String(editingPlan.enrollment_period_end).slice(0, 10)
+                  : ""
+              }
+            />
           </div>
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={() => setShowCreatePlan(false)}>
+            <Button type="button" variant="ghost" onClick={closePlanModal}>
               Cancel
             </Button>
             <Button type="submit" disabled={creating}>
               {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Create Plan
+              {editingPlan ? "Update Plan" : "Create Plan"}
             </Button>
           </div>
         </form>

--- a/packages/server/src/api/routes/benefits.routes.ts
+++ b/packages/server/src/api/routes/benefits.routes.ts
@@ -1,7 +1,12 @@
 import { Router } from "express";
 import { BenefitsService } from "../../services/benefits.service";
 import { authenticate, authorize } from "../middleware/auth.middleware";
-import { validate, createBenefitPlanSchema, enrollBenefitSchema } from "../validators";
+import {
+  validate,
+  createBenefitPlanSchema,
+  updateBenefitPlanSchema,
+  enrollBenefitSchema,
+} from "../validators";
 import { wrap, param } from "../helpers";
 
 const router = Router();
@@ -60,6 +65,7 @@ router.post(
 router.put(
   "/plans/:id",
   authorize("hr_admin"),
+  validate(updateBenefitPlanSchema),
   wrap(async (req, res) => {
     const data = await svc.updatePlan(param(req, "id"), String(req.user!.empcloudOrgId), req.body);
     res.json({ success: true, data });

--- a/packages/server/src/api/routes/compensation-benchmark.routes.ts
+++ b/packages/server/src/api/routes/compensation-benchmark.routes.ts
@@ -1,7 +1,12 @@
 import { Router } from "express";
 import { CompensationBenchmarkService } from "../../services/compensation-benchmark.service";
 import { authenticate, authorize } from "../middleware/auth.middleware";
-import { validate, createBenchmarkSchema, importBenchmarksSchema } from "../validators";
+import {
+  validate,
+  createBenchmarkSchema,
+  updateBenchmarkSchema,
+  importBenchmarksSchema,
+} from "../validators";
 import { wrap, param } from "../helpers";
 
 const router = Router();
@@ -45,6 +50,7 @@ router.post(
 router.put(
   "/:id",
   authorize("hr_admin"),
+  validate(updateBenchmarkSchema),
   wrap(async (req, res) => {
     const data = await svc.updateBenchmark(
       param(req, "id"),

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -333,6 +333,20 @@ export const createBenchmarkSchema = z.object({
   }),
 });
 
+export const updateBenchmarkSchema = z.object({
+  params: z.object({ id: z.string() }),
+  body: z.object({
+    jobTitle: z.string().min(1).max(255).optional(),
+    department: z.string().max(100).optional().nullable(),
+    location: z.string().max(255).optional().nullable(),
+    marketP25: z.number().min(0).optional(),
+    marketP50: z.number().min(0).optional(),
+    marketP75: z.number().min(0).optional(),
+    source: z.string().max(255).optional().nullable(),
+    effectiveDate: z.string().optional(),
+  }),
+});
+
 export const importBenchmarksSchema = z.object({
   body: z.object({
     benchmarks: z

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -263,40 +263,96 @@ export const createOrgSchema = z.object({
 // ---------------------------------------------------------------------------
 // Benefits Schemas
 // ---------------------------------------------------------------------------
+// Reusable helper — guards any schema where both startKey and endKey are
+// optional date strings. Fails with a clear "end must be on or after start"
+// message so the UI can surface it inline. Shared by the benefit-plan /
+// benefit-enrollment schemas (both affected by #15) and reused by the
+// insurance schemas (#13).
+function refineDateRange<T extends z.ZodRawShape>(
+  shape: z.ZodObject<T>,
+  startKey: keyof T & string,
+  endKey: keyof T & string,
+  label: string,
+) {
+  return shape.refine(
+    (v: any) => {
+      if (!v[startKey] || !v[endKey]) return true;
+      return new Date(v[endKey]).getTime() >= new Date(v[startKey]).getTime();
+    },
+    {
+      message: `${label} end date must be on or after start date`,
+      path: [endKey],
+    },
+  );
+}
+
 export const createBenefitPlanSchema = z.object({
-  body: z.object({
-    name: z.string().min(1).max(100),
-    type: z.enum(["health", "dental", "vision", "life", "disability", "retirement"]),
-    provider: z.string().max(255).optional(),
-    description: z.string().optional(),
-    premiumAmount: z.number().min(0).default(0),
-    employerContribution: z.number().min(0).default(0),
-    coverageDetails: z.record(z.any()).optional(),
-    enrollmentPeriodStart: z.string().optional(),
-    enrollmentPeriodEnd: z.string().optional(),
-  }),
+  body: refineDateRange(
+    z.object({
+      name: z.string().min(1).max(100),
+      type: z.enum(["health", "dental", "vision", "life", "disability", "retirement"]),
+      provider: z.string().max(255).optional(),
+      description: z.string().optional(),
+      premiumAmount: z.number().min(0).default(0),
+      employerContribution: z.number().min(0).default(0),
+      coverageDetails: z.record(z.any()).optional(),
+      enrollmentPeriodStart: z.string().optional(),
+      enrollmentPeriodEnd: z.string().optional(),
+    }),
+    "enrollmentPeriodStart",
+    "enrollmentPeriodEnd",
+    "Enrollment period",
+  ),
+});
+
+export const updateBenefitPlanSchema = z.object({
+  params: z.object({ id: z.string() }),
+  body: refineDateRange(
+    z.object({
+      name: z.string().min(1).max(100).optional(),
+      type: z.enum(["health", "dental", "vision", "life", "disability", "retirement"]).optional(),
+      provider: z.string().max(255).optional().nullable(),
+      description: z.string().optional().nullable(),
+      premiumAmount: z.number().min(0).optional(),
+      employerContribution: z.number().min(0).optional(),
+      coverageDetails: z.record(z.any()).optional(),
+      enrollmentPeriodStart: z.string().optional().nullable(),
+      enrollmentPeriodEnd: z.string().optional().nullable(),
+      isActive: z.boolean().optional(),
+    }),
+    "enrollmentPeriodStart",
+    "enrollmentPeriodEnd",
+    "Enrollment period",
+  ),
 });
 
 export const enrollBenefitSchema = z.object({
-  body: z.object({
-    employeeId: z.union([z.string(), z.number()]).transform(String),
-    planId: z.string(),
-    coverageType: z.enum(["individual", "family", "individual_plus_spouse"]).default("individual"),
-    startDate: z.string(),
-    endDate: z.string().optional(),
-    status: z.enum(["enrolled", "pending"]).default("pending"),
-    premiumEmployeeShare: z.number().min(0).default(0),
-    premiumEmployerShare: z.number().min(0).optional(),
-    dependents: z
-      .array(
-        z.object({
-          name: z.string().min(1).max(255),
-          relationship: z.enum(["spouse", "child", "parent"]),
-          dateOfBirth: z.string().optional(),
-        }),
-      )
-      .optional(),
-  }),
+  body: refineDateRange(
+    z.object({
+      employeeId: z.union([z.string(), z.number()]).transform(String),
+      planId: z.string(),
+      coverageType: z
+        .enum(["individual", "family", "individual_plus_spouse"])
+        .default("individual"),
+      startDate: z.string(),
+      endDate: z.string().optional(),
+      status: z.enum(["enrolled", "pending"]).default("pending"),
+      premiumEmployeeShare: z.number().min(0).default(0),
+      premiumEmployerShare: z.number().min(0).optional(),
+      dependents: z
+        .array(
+          z.object({
+            name: z.string().min(1).max(255),
+            relationship: z.enum(["spouse", "child", "parent"]),
+            dateOfBirth: z.string().optional(),
+          }),
+        )
+        .optional(),
+    }),
+    "startDate",
+    "endDate",
+    "Enrollment",
+  ),
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #16. Closes #15.

## #16 — Edit / Delete missing on Benefits plans
`planColumns` rendered no actions cell — the UI had no way to modify or deactivate a plan even though `PUT /benefits/plans/:id` + `DELETE /benefits/plans/:id` were wired server-side with real service methods.

**Fix (client)**:
- Added a `Pencil` + `Trash2` button group in the row. Pencil sets `editingPlan` state and re-purposes the existing Create Plan modal — title flips to *Edit Benefit Plan*, inputs pre-fill from the row's snake_case columns, submit label becomes *Update Plan*, and the handler calls `apiPut` vs `apiPost` based on the state.
- `Trash2` calls `DELETE /benefits/plans/:id` after a confirm prompt. Hidden once the plan is already `is_active = false` so it doesn't show after one click.

**Fix (server)**:
- Added `updateBenefitPlanSchema` (same fields as create, all optional for partial updates) and wired it via `validate(...)` on the PUT route. Previously the route had no validator, so curl callers could send arbitrary payloads.

## #15 — Enrollment end date before start date
Neither `createBenefitPlanSchema` nor `enrollBenefitSchema` cross-validated their date pairs, so a plan or enrollment could be saved with `end < start` (UI didn't block it either).

**Fix (server)**:
- Added a small reusable `refineDateRange(shape, startKey, endKey, label)` helper that returns a `ZodEffects` wrapping the shape with the correct cross-field refinement. Applied it to:
  - `createBenefitPlanSchema` → `enrollmentPeriodStart` / `enrollmentPeriodEnd`
  - `updateBenefitPlanSchema` → same
  - `enrollBenefitSchema` → `startDate` / `endDate`
- 400 `VALIDATION_ERROR` with message *"Enrollment period end date must be on or after start date"* (or *"Enrollment end date…"* for the enroll schema), `path: [endKey]` so the UI can target the error to the right field.

**Fix (client)**:
- Pre-submit guard in the Create/Edit Plan form — toasts *"Enrollment end date cannot be before start date"* and early-returns before the API call.
- When the start date is picked, the end date input's `min` is updated so the browser's native date picker blocks earlier selections in the first place.

The helper is deliberately placed at the top of the validators file — the next PR (Insurance) reuses it for the same bug there (#13).

## Files
- `packages/client/src/pages/benefits/BenefitsPage.tsx`
- `packages/server/src/api/routes/benefits.routes.ts`
- `packages/server/src/api/validators/index.ts`

## Test plan
- [x] Plans row shows Pencil + Trash2.
- [x] Pencil → modal opens pre-filled → change a field → *Update Plan* → row reflects changes.
- [x] Trash2 → confirm → plan becomes `Inactive`, trash icon disappears on that row.
- [x] Create a plan with `enrollmentPeriodEnd < enrollmentPeriodStart` via curl → 400 with the cross-field message.
- [x] Same via the form → toast shown, no request fired.
- [x] Selecting a start date updates the end input's `min` so the native picker refuses earlier dates.
- [x] Enroll employee with `endDate < startDate` via curl → 400 with the enrollment message.
- [x] `pnpm --filter @emp-payroll/server exec tsc --noEmit` and `--filter @emp-payroll/client` both pass.