### PR TITLE
fix(insurance): add Edit/Delete on policies + reject end-date < start-date

### DIFF
--- a/packages/client/src/pages/benchmarks/BenchmarksPage.tsx
+++ b/packages/client/src/pages/benchmarks/BenchmarksPage.tsx
@@ -8,7 +8,7 @@ import { Modal } from "@/components/ui/Modal";
 import { DataTable } from "@/components/ui/DataTable";
 import { StatCard } from "@/components/ui/StatCard";
 import { formatCurrency, formatDate } from "@/lib/utils";
-import { apiGet, apiPost, apiDelete } from "@/api/client";
+import { apiGet, apiPost, apiPut, apiDelete } from "@/api/client";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Plus,
@@ -19,6 +19,7 @@ import {
   Minus,
   Loader2,
   Trash2,
+  Pencil,
   FileUp,
 } from "lucide-react";
 import toast from "react-hot-toast";
@@ -27,6 +28,9 @@ export function BenchmarksPage() {
   const [tab, setTab] = useState<"benchmarks" | "compa-ratio">("benchmarks");
   const [showCreate, setShowCreate] = useState(false);
   const [creating, setCreating] = useState(false);
+  // When set, the create modal re-purposes itself as an edit form pre-filled
+  // with this row's values (issue #18 — edit button was missing entirely).
+  const [editing, setEditing] = useState<any>(null);
   const qc = useQueryClient();
 
   const { data: benchRes, isLoading: benchLoading } = useQuery({
@@ -44,23 +48,34 @@ export function BenchmarksPage() {
   const compaData = compaRes?.data || {};
   const compaEmployees = compaData.employees || [];
 
-  async function handleCreate(e: React.FormEvent<HTMLFormElement>) {
+  function closeModal() {
+    setShowCreate(false);
+    setEditing(null);
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setCreating(true);
     const fd = new FormData(e.currentTarget);
+    const payload = {
+      jobTitle: fd.get("jobTitle"),
+      department: fd.get("department"),
+      location: fd.get("location"),
+      marketP25: Number(fd.get("marketP25")),
+      marketP50: Number(fd.get("marketP50")),
+      marketP75: Number(fd.get("marketP75")),
+      source: fd.get("source"),
+      effectiveDate: fd.get("effectiveDate"),
+    };
     try {
-      await apiPost("/benchmarks", {
-        jobTitle: fd.get("jobTitle"),
-        department: fd.get("department"),
-        location: fd.get("location"),
-        marketP25: Number(fd.get("marketP25")),
-        marketP50: Number(fd.get("marketP50")),
-        marketP75: Number(fd.get("marketP75")),
-        source: fd.get("source"),
-        effectiveDate: fd.get("effectiveDate"),
-      });
-      toast.success("Benchmark created");
-      setShowCreate(false);
+      if (editing) {
+        await apiPut(`/benchmarks/${editing.id}`, payload);
+        toast.success("Benchmark updated");
+      } else {
+        await apiPost("/benchmarks", payload);
+        toast.success("Benchmark created");
+      }
+      closeModal();
       qc.invalidateQueries({ queryKey: ["benchmarks"] });
     } catch (err: any) {
       toast.error(err.response?.data?.error?.message || "Failed");
@@ -108,14 +123,28 @@ export function BenchmarksPage() {
       key: "actions",
       header: "",
       render: (r: any) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => deleteBenchmark(r.id)}
-          className="text-red-600"
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            title="Edit"
+            onClick={() => {
+              setEditing(r);
+              setShowCreate(true);
+            }}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            title="Delete"
+            onClick={() => deleteBenchmark(r.id)}
+            className="text-red-600"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
       ),
     },
   ];
@@ -283,34 +312,91 @@ export function BenchmarksPage() {
         </>
       )}
 
-      {/* Create Benchmark Modal */}
+      {/* Create / Edit Benchmark Modal — same form re-purposed as edit when
+          `editing` is set. Issue #17: the P25/P50/P75 inputs now carry
+          min=0 so the stepper can't decrement into negative salary values.
+          Issue #18: the Edit button that populates `editing` and opens
+          this modal was previously missing. */}
       <Modal
         open={showCreate}
-        onClose={() => setShowCreate(false)}
-        title="Add Compensation Benchmark"
+        onClose={closeModal}
+        title={editing ? "Edit Compensation Benchmark" : "Add Compensation Benchmark"}
       >
-        <form onSubmit={handleCreate} className="space-y-4">
-          <Input label="Job Title" name="jobTitle" placeholder="e.g., Software Engineer" required />
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            label="Job Title"
+            name="jobTitle"
+            placeholder="e.g., Software Engineer"
+            defaultValue={editing?.job_title || ""}
+            required
+          />
           <div className="grid grid-cols-2 gap-4">
-            <Input label="Department" name="department" placeholder="e.g., Engineering" />
-            <Input label="Location" name="location" placeholder="e.g., Bangalore" />
+            <Input
+              label="Department"
+              name="department"
+              placeholder="e.g., Engineering"
+              defaultValue={editing?.department || ""}
+            />
+            <Input
+              label="Location"
+              name="location"
+              placeholder="e.g., Bangalore"
+              defaultValue={editing?.location || ""}
+            />
           </div>
           <div className="grid grid-cols-3 gap-4">
-            <Input label="P25 (Annual)" name="marketP25" type="number" required />
-            <Input label="P50 Median (Annual)" name="marketP50" type="number" required />
-            <Input label="P75 (Annual)" name="marketP75" type="number" required />
+            <Input
+              label="P25 (Annual)"
+              name="marketP25"
+              type="number"
+              min={0}
+              step="any"
+              defaultValue={editing?.market_p25 ?? ""}
+              required
+            />
+            <Input
+              label="P50 Median (Annual)"
+              name="marketP50"
+              type="number"
+              min={0}
+              step="any"
+              defaultValue={editing?.market_p50 ?? ""}
+              required
+            />
+            <Input
+              label="P75 (Annual)"
+              name="marketP75"
+              type="number"
+              min={0}
+              step="any"
+              defaultValue={editing?.market_p75 ?? ""}
+              required
+            />
           </div>
           <div className="grid grid-cols-2 gap-4">
-            <Input label="Source" name="source" placeholder="e.g., Glassdoor 2026" />
-            <Input label="Effective Date" name="effectiveDate" type="date" required />
+            <Input
+              label="Source"
+              name="source"
+              placeholder="e.g., Glassdoor 2026"
+              defaultValue={editing?.source || ""}
+            />
+            <Input
+              label="Effective Date"
+              name="effectiveDate"
+              type="date"
+              defaultValue={
+                editing?.effective_date ? String(editing.effective_date).slice(0, 10) : ""
+              }
+              required
+            />
           </div>
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={() => setShowCreate(false)}>
+            <Button type="button" variant="ghost" onClick={closeModal}>
               Cancel
             </Button>
             <Button type="submit" disabled={creating}>
               {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Save Benchmark
+              {editing ? "Update Benchmark" : "Save Benchmark"}
             </Button>
           </div>
         </form>

--- a/packages/client/src/pages/benefits/BenefitsPage.tsx
+++ b/packages/client/src/pages/benefits/BenefitsPage.tsx
@@ -9,10 +9,20 @@ import { Modal } from "@/components/ui/Modal";
 import { DataTable } from "@/components/ui/DataTable";
 import { StatCard } from "@/components/ui/StatCard";
 import { formatCurrency } from "@/lib/utils";
-import { apiGet, apiPost, apiPut } from "@/api/client";
+import { apiGet, apiPost, apiPut, apiDelete } from "@/api/client";
 import { useEmployees } from "@/api/hooks";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plus, Heart, Shield, Users, DollarSign, UserPlus, Loader2 } from "lucide-react";
+import {
+  Plus,
+  Heart,
+  Shield,
+  Users,
+  DollarSign,
+  UserPlus,
+  Loader2,
+  Pencil,
+  Trash2,
+} from "lucide-react";
 import toast from "react-hot-toast";
 
 const PLAN_TYPES = [
@@ -35,6 +45,8 @@ export function BenefitsPage() {
   const [showCreatePlan, setShowCreatePlan] = useState(false);
   const [showEnroll, setShowEnroll] = useState(false);
   const [creating, setCreating] = useState(false);
+  // When set, the plan modal re-purposes as edit (#16).
+  const [editingPlan, setEditingPlan] = useState<any>(null);
   const qc = useQueryClient();
   const { data: empRes } = useEmployees({ limit: 200 });
 
@@ -58,29 +70,59 @@ export function BenefitsPage() {
   const enrollments = enrollRes?.data || [];
   const employees = empRes?.data?.data || [];
 
-  async function handleCreatePlan(e: React.FormEvent<HTMLFormElement>) {
+  function closePlanModal() {
+    setShowCreatePlan(false);
+    setEditingPlan(null);
+  }
+
+  async function handlePlanSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setCreating(true);
     const fd = new FormData(e.currentTarget);
+    const start = String(fd.get("enrollmentPeriodStart") || "");
+    const end = String(fd.get("enrollmentPeriodEnd") || "");
+    // Client-side guard for #15 — server also rejects, but we fail fast.
+    if (start && end && new Date(end).getTime() < new Date(start).getTime()) {
+      toast.error("Enrollment end date cannot be before start date");
+      return;
+    }
+    setCreating(true);
+    const payload = {
+      name: fd.get("name"),
+      type: fd.get("type"),
+      provider: fd.get("provider"),
+      description: fd.get("description"),
+      premiumAmount: Number(fd.get("premiumAmount") || 0),
+      employerContribution: Number(fd.get("employerContribution") || 0),
+      enrollmentPeriodStart: start || undefined,
+      enrollmentPeriodEnd: end || undefined,
+    };
     try {
-      await apiPost("/benefits/plans", {
-        name: fd.get("name"),
-        type: fd.get("type"),
-        provider: fd.get("provider"),
-        description: fd.get("description"),
-        premiumAmount: Number(fd.get("premiumAmount") || 0),
-        employerContribution: Number(fd.get("employerContribution") || 0),
-        enrollmentPeriodStart: fd.get("enrollmentPeriodStart") || undefined,
-        enrollmentPeriodEnd: fd.get("enrollmentPeriodEnd") || undefined,
-      });
-      toast.success("Benefit plan created");
-      setShowCreatePlan(false);
+      if (editingPlan) {
+        await apiPut(`/benefits/plans/${editingPlan.id}`, payload);
+        toast.success("Benefit plan updated");
+      } else {
+        await apiPost("/benefits/plans", payload);
+        toast.success("Benefit plan created");
+      }
+      closePlanModal();
       qc.invalidateQueries({ queryKey: ["benefit-plans"] });
       qc.invalidateQueries({ queryKey: ["benefits-dashboard"] });
     } catch (err: any) {
-      toast.error(err.response?.data?.error?.message || "Failed to create plan");
+      toast.error(err.response?.data?.error?.message || "Failed to save plan");
     } finally {
       setCreating(false);
+    }
+  }
+
+  async function deletePlan(id: string) {
+    if (!confirm("Deactivate this benefit plan? Existing enrollments are unaffected.")) return;
+    try {
+      await apiDelete(`/benefits/plans/${id}`);
+      toast.success("Benefit plan deactivated");
+      qc.invalidateQueries({ queryKey: ["benefit-plans"] });
+      qc.invalidateQueries({ queryKey: ["benefits-dashboard"] });
+    } catch (err: any) {
+      toast.error(err.response?.data?.error?.message || "Failed to deactivate plan");
     }
   }
 
@@ -149,6 +191,36 @@ export function BenefitsPage() {
         <Badge variant={r.is_active ? "active" : "inactive"}>
           {r.is_active ? "Active" : "Inactive"}
         </Badge>
+      ),
+    },
+    {
+      key: "actions",
+      header: "",
+      render: (r: any) => (
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            title="Edit"
+            onClick={() => {
+              setEditingPlan(r);
+              setShowCreatePlan(true);
+            }}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+          {r.is_active && (
+            <Button
+              variant="ghost"
+              size="sm"
+              title="Deactivate"
+              onClick={() => deletePlan(r.id)}
+              className="text-red-600"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
       ),
     },
   ];
@@ -293,37 +365,84 @@ export function BenefitsPage() {
         </Card>
       )}
 
-      {/* Create Plan Modal */}
+      {/* Create / Edit Plan Modal — one form for both flows (#16). */}
       <Modal
         open={showCreatePlan}
-        onClose={() => setShowCreatePlan(false)}
-        title="Create Benefit Plan"
+        onClose={closePlanModal}
+        title={editingPlan ? "Edit Benefit Plan" : "Create Benefit Plan"}
+        key={editingPlan?.id || "new-plan"}
       >
-        <form onSubmit={handleCreatePlan} className="space-y-4">
-          <Input label="Plan Name" name="name" required />
-          <SelectField label="Type" name="type" options={PLAN_TYPES} required />
-          <Input label="Provider" name="provider" />
-          <Input label="Description" name="description" />
+        <form onSubmit={handlePlanSubmit} className="space-y-4">
+          <Input label="Plan Name" name="name" defaultValue={editingPlan?.name || ""} required />
+          <SelectField
+            label="Type"
+            name="type"
+            options={PLAN_TYPES}
+            defaultValue={editingPlan?.type || ""}
+            required
+          />
+          <Input label="Provider" name="provider" defaultValue={editingPlan?.provider || ""} />
+          <Input
+            label="Description"
+            name="description"
+            defaultValue={editingPlan?.description || ""}
+          />
           <div className="grid grid-cols-2 gap-4">
-            <Input label="Monthly Premium" name="premiumAmount" type="number" step="0.01" />
+            <Input
+              label="Monthly Premium"
+              name="premiumAmount"
+              type="number"
+              step="0.01"
+              min={0}
+              defaultValue={editingPlan?.premium_amount ?? ""}
+            />
             <Input
               label="Employer Contribution"
               name="employerContribution"
               type="number"
               step="0.01"
+              min={0}
+              defaultValue={editingPlan?.employer_contribution ?? ""}
             />
           </div>
           <div className="grid grid-cols-2 gap-4">
-            <Input label="Enrollment Start" name="enrollmentPeriodStart" type="date" />
-            <Input label="Enrollment End" name="enrollmentPeriodEnd" type="date" />
+            <Input
+              label="Enrollment Start"
+              name="enrollmentPeriodStart"
+              type="date"
+              defaultValue={
+                editingPlan?.enrollment_period_start
+                  ? String(editingPlan.enrollment_period_start).slice(0, 10)
+                  : ""
+              }
+              onChange={(e) => {
+                // Push the selected start date as the minimum for the end date input,
+                // so the browser's date picker blocks earlier selections (#15).
+                const form = (e.currentTarget as HTMLInputElement).form;
+                const endInput = form?.elements.namedItem(
+                  "enrollmentPeriodEnd",
+                ) as HTMLInputElement | null;
+                if (endInput) endInput.min = e.currentTarget.value;
+              }}
+            />
+            <Input
+              label="Enrollment End"
+              name="enrollmentPeriodEnd"
+              type="date"
+              defaultValue={
+                editingPlan?.enrollment_period_end
+                  ? String(editingPlan.enrollment_period_end).slice(0, 10)
+                  : ""
+              }
+            />
           </div>
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={() => setShowCreatePlan(false)}>
+            <Button type="button" variant="ghost" onClick={closePlanModal}>
               Cancel
             </Button>
             <Button type="submit" disabled={creating}>
               {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Create Plan
+              {editingPlan ? "Update Plan" : "Create Plan"}
             </Button>
           </div>
         </form>

--- a/packages/client/src/pages/insurance/InsurancePage.tsx
+++ b/packages/client/src/pages/insurance/InsurancePage.tsx
@@ -9,7 +9,7 @@ import { Modal } from "@/components/ui/Modal";
 import { DataTable } from "@/components/ui/DataTable";
 import { StatCard } from "@/components/ui/StatCard";
 import { formatCurrency } from "@/lib/utils";
-import { apiGet, apiPost, apiPut } from "@/api/client";
+import { apiGet, apiPost, apiPut, apiDelete } from "@/api/client";
 import { useEmployees } from "@/api/hooks";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -24,6 +24,8 @@ import {
   CheckCircle,
   XCircle,
   CreditCard,
+  Pencil,
+  Trash2,
 } from "lucide-react";
 import toast from "react-hot-toast";
 
@@ -63,6 +65,8 @@ export function InsurancePage() {
   const [showEnroll, setShowEnroll] = useState(false);
   const [showSubmitClaim, setShowSubmitClaim] = useState(false);
   const [saving, setSaving] = useState(false);
+  // When set, the policy modal acts as Edit (#14).
+  const [editingPolicy, setEditingPolicy] = useState<any>(null);
   const qc = useQueryClient();
   const { data: empRes } = useEmployees({ limit: 200 });
 
@@ -94,32 +98,62 @@ export function InsurancePage() {
   const employees = empRes?.data?.data || [];
 
   // --- Handlers ---
-  async function handleCreatePolicy(e: React.FormEvent<HTMLFormElement>) {
+  function closePolicyModal() {
+    setShowCreatePolicy(false);
+    setEditingPolicy(null);
+  }
+
+  async function handlePolicySubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setSaving(true);
     const fd = new FormData(e.currentTarget);
+    const start = String(fd.get("startDate") || "");
+    const end = String(fd.get("endDate") || "");
+    // Client-side guard for #13 — server rejects too but we fail fast.
+    if (start && end && new Date(end).getTime() < new Date(start).getTime()) {
+      toast.error("Policy end date cannot be before start date");
+      return;
+    }
+    setSaving(true);
+    const payload = {
+      name: fd.get("name"),
+      policyNumber: fd.get("policyNumber") || undefined,
+      provider: fd.get("provider"),
+      type: fd.get("type"),
+      premiumTotal: Number(fd.get("premiumTotal") || 0),
+      premiumPerEmployee: Number(fd.get("premiumPerEmployee") || 0),
+      coverageAmount: Number(fd.get("coverageAmount") || 0),
+      startDate: start,
+      endDate: end || undefined,
+      renewalDate: fd.get("renewalDate") || undefined,
+      terms: fd.get("terms") || undefined,
+    };
     try {
-      await apiPost("/insurance/policies", {
-        name: fd.get("name"),
-        policyNumber: fd.get("policyNumber") || undefined,
-        provider: fd.get("provider"),
-        type: fd.get("type"),
-        premiumTotal: Number(fd.get("premiumTotal") || 0),
-        premiumPerEmployee: Number(fd.get("premiumPerEmployee") || 0),
-        coverageAmount: Number(fd.get("coverageAmount") || 0),
-        startDate: fd.get("startDate"),
-        endDate: fd.get("endDate") || undefined,
-        renewalDate: fd.get("renewalDate") || undefined,
-        terms: fd.get("terms") || undefined,
-      });
-      toast.success("Insurance policy created");
-      setShowCreatePolicy(false);
+      if (editingPolicy) {
+        await apiPut(`/insurance/policies/${editingPolicy.id}`, payload);
+        toast.success("Insurance policy updated");
+      } else {
+        await apiPost("/insurance/policies", payload);
+        toast.success("Insurance policy created");
+      }
+      closePolicyModal();
       qc.invalidateQueries({ queryKey: ["insurance-policies"] });
       qc.invalidateQueries({ queryKey: ["insurance-dashboard"] });
     } catch (err: any) {
-      toast.error(err.response?.data?.error?.message || "Failed to create policy");
+      toast.error(err.response?.data?.error?.message || "Failed to save policy");
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function deletePolicy(id: string) {
+    if (!confirm("Deactivate this insurance policy? Existing enrollments are unaffected.")) return;
+    try {
+      await apiDelete(`/insurance/policies/${id}`);
+      toast.success("Insurance policy deactivated");
+      qc.invalidateQueries({ queryKey: ["insurance-policies"] });
+      qc.invalidateQueries({ queryKey: ["insurance-dashboard"] });
+    } catch (err: any) {
+      toast.error(err.response?.data?.error?.message || "Failed to deactivate policy");
     }
   }
 
@@ -250,6 +284,36 @@ export function InsurancePage() {
       key: "status",
       header: "Status",
       render: (r: any) => <Badge variant={STATUS_BADGE[r.status] || "draft"}>{r.status}</Badge>,
+    },
+    {
+      key: "actions",
+      header: "",
+      render: (r: any) => (
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            title="Edit"
+            onClick={() => {
+              setEditingPolicy(r);
+              setShowCreatePolicy(true);
+            }}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+          {r.status === "active" && (
+            <Button
+              variant="ghost"
+              size="sm"
+              title="Deactivate"
+              onClick={() => deletePolicy(r.id)}
+              className="text-red-600"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      ),
     },
   ];
 
@@ -485,42 +549,114 @@ export function InsurancePage() {
         </Card>
       )}
 
-      {/* Create Policy Modal */}
+      {/* Create / Edit Policy Modal — one form serves both flows (#14).
+          End-date input has a dynamic `min` based on the picked start date
+          so the native date picker blocks invalid earlier choices (#13). */}
       <Modal
         open={showCreatePolicy}
-        onClose={() => setShowCreatePolicy(false)}
-        title="Create Insurance Policy"
+        onClose={closePolicyModal}
+        title={editingPolicy ? "Edit Insurance Policy" : "Create Insurance Policy"}
+        key={editingPolicy?.id || "new-policy"}
       >
-        <form onSubmit={handleCreatePolicy} className="space-y-4">
-          <Input label="Policy Name" name="name" required />
+        <form onSubmit={handlePolicySubmit} className="space-y-4">
+          <Input
+            label="Policy Name"
+            name="name"
+            defaultValue={editingPolicy?.name || ""}
+            required
+          />
           <div className="grid grid-cols-2 gap-4">
-            <Input label="Policy Number" name="policyNumber" />
-            <Input label="Provider" name="provider" required />
+            <Input
+              label="Policy Number"
+              name="policyNumber"
+              defaultValue={editingPolicy?.policy_number || ""}
+            />
+            <Input
+              label="Provider"
+              name="provider"
+              defaultValue={editingPolicy?.provider || ""}
+              required
+            />
           </div>
-          <SelectField label="Type" name="type" options={POLICY_TYPES} required />
+          <SelectField
+            label="Type"
+            name="type"
+            options={POLICY_TYPES}
+            defaultValue={editingPolicy?.type || ""}
+            required
+          />
           <div className="grid grid-cols-3 gap-4">
-            <Input label="Total Premium" name="premiumTotal" type="number" defaultValue="0" />
+            <Input
+              label="Total Premium"
+              name="premiumTotal"
+              type="number"
+              min={0}
+              defaultValue={editingPolicy?.premium_total ?? "0"}
+            />
             <Input
               label="Premium / Employee"
               name="premiumPerEmployee"
               type="number"
-              defaultValue="0"
+              min={0}
+              defaultValue={editingPolicy?.premium_per_employee ?? "0"}
             />
-            <Input label="Coverage Amount" name="coverageAmount" type="number" defaultValue="0" />
+            <Input
+              label="Coverage Amount"
+              name="coverageAmount"
+              type="number"
+              min={0}
+              defaultValue={editingPolicy?.coverage_amount ?? "0"}
+            />
           </div>
           <div className="grid grid-cols-3 gap-4">
-            <Input label="Start Date" name="startDate" type="date" required />
-            <Input label="End Date" name="endDate" type="date" />
-            <Input label="Renewal Date" name="renewalDate" type="date" />
+            <Input
+              label="Start Date"
+              name="startDate"
+              type="date"
+              defaultValue={
+                editingPolicy?.start_date ? String(editingPolicy.start_date).slice(0, 10) : ""
+              }
+              required
+              onChange={(e) => {
+                const form = (e.currentTarget as HTMLInputElement).form;
+                const endInput = form?.elements.namedItem("endDate") as HTMLInputElement | null;
+                if (endInput) endInput.min = e.currentTarget.value;
+              }}
+            />
+            <Input
+              label="End Date"
+              name="endDate"
+              type="date"
+              defaultValue={
+                editingPolicy?.end_date ? String(editingPolicy.end_date).slice(0, 10) : ""
+              }
+              min={
+                editingPolicy?.start_date
+                  ? String(editingPolicy.start_date).slice(0, 10)
+                  : undefined
+              }
+            />
+            <Input
+              label="Renewal Date"
+              name="renewalDate"
+              type="date"
+              defaultValue={
+                editingPolicy?.renewal_date ? String(editingPolicy.renewal_date).slice(0, 10) : ""
+              }
+            />
           </div>
-          <Input label="Terms & Conditions" name="terms" />
+          <Input
+            label="Terms & Conditions"
+            name="terms"
+            defaultValue={editingPolicy?.terms || ""}
+          />
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={() => setShowCreatePolicy(false)}>
+            <Button type="button" variant="ghost" onClick={closePolicyModal}>
               Cancel
             </Button>
             <Button type="submit" disabled={saving}>
               {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Create Policy
+              {editingPolicy ? "Update Policy" : "Create Policy"}
             </Button>
           </div>
         </form>

--- a/packages/server/src/api/routes/benefits.routes.ts
+++ b/packages/server/src/api/routes/benefits.routes.ts
@@ -1,7 +1,12 @@
 import { Router } from "express";
 import { BenefitsService } from "../../services/benefits.service";
 import { authenticate, authorize } from "../middleware/auth.middleware";
-import { validate, createBenefitPlanSchema, enrollBenefitSchema } from "../validators";
+import {
+  validate,
+  createBenefitPlanSchema,
+  updateBenefitPlanSchema,
+  enrollBenefitSchema,
+} from "../validators";
 import { wrap, param } from "../helpers";
 
 const router = Router();
@@ -60,6 +65,7 @@ router.post(
 router.put(
   "/plans/:id",
   authorize("hr_admin"),
+  validate(updateBenefitPlanSchema),
   wrap(async (req, res) => {
     const data = await svc.updatePlan(param(req, "id"), String(req.user!.empcloudOrgId), req.body);
     res.json({ success: true, data });

--- a/packages/server/src/api/routes/compensation-benchmark.routes.ts
+++ b/packages/server/src/api/routes/compensation-benchmark.routes.ts
@@ -1,7 +1,12 @@
 import { Router } from "express";
 import { CompensationBenchmarkService } from "../../services/compensation-benchmark.service";
 import { authenticate, authorize } from "../middleware/auth.middleware";
-import { validate, createBenchmarkSchema, importBenchmarksSchema } from "../validators";
+import {
+  validate,
+  createBenchmarkSchema,
+  updateBenchmarkSchema,
+  importBenchmarksSchema,
+} from "../validators";
 import { wrap, param } from "../helpers";
 
 const router = Router();
@@ -45,6 +50,7 @@ router.post(
 router.put(
   "/:id",
   authorize("hr_admin"),
+  validate(updateBenchmarkSchema),
   wrap(async (req, res) => {
     const data = await svc.updateBenchmark(
       param(req, "id"),

--- a/packages/server/src/api/routes/insurance.routes.ts
+++ b/packages/server/src/api/routes/insurance.routes.ts
@@ -4,6 +4,7 @@ import { authenticate, authorize } from "../middleware/auth.middleware";
 import {
   validate,
   createInsurancePolicySchema,
+  updateInsurancePolicySchema,
   enrollInsuranceSchema,
   submitInsuranceClaimSchema,
   reviewInsuranceClaimSchema,
@@ -66,6 +67,7 @@ router.post(
 router.put(
   "/policies/:id",
   authorize("hr_admin"),
+  validate(updateInsurancePolicySchema),
   wrap(async (req, res) => {
     const data = await svc.updatePolicy(
       param(req, "id"),

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -456,20 +456,49 @@ export const earnedWageRejectSchema = z.object({
 // Insurance Schemas
 // ---------------------------------------------------------------------------
 export const createInsurancePolicySchema = z.object({
-  body: z.object({
-    name: z.string().min(1).max(255),
-    policyNumber: z.string().max(100).optional(),
-    provider: z.string().min(1).max(255),
-    type: z.enum(["group_health", "group_life", "disability", "accidental", "travel"]),
-    premiumTotal: z.number().min(0).default(0),
-    premiumPerEmployee: z.number().min(0).default(0),
-    coverageAmount: z.number().min(0).default(0),
-    startDate: z.string(),
-    endDate: z.string().optional(),
-    renewalDate: z.string().optional(),
-    documentUrl: z.string().optional(),
-    terms: z.string().optional(),
-  }),
+  body: refineDateRange(
+    z.object({
+      name: z.string().min(1).max(255),
+      policyNumber: z.string().max(100).optional(),
+      provider: z.string().min(1).max(255),
+      type: z.enum(["group_health", "group_life", "disability", "accidental", "travel"]),
+      premiumTotal: z.number().min(0).default(0),
+      premiumPerEmployee: z.number().min(0).default(0),
+      coverageAmount: z.number().min(0).default(0),
+      startDate: z.string(),
+      endDate: z.string().optional(),
+      renewalDate: z.string().optional(),
+      documentUrl: z.string().optional(),
+      terms: z.string().optional(),
+    }),
+    "startDate",
+    "endDate",
+    "Policy",
+  ),
+});
+
+export const updateInsurancePolicySchema = z.object({
+  params: z.object({ id: z.string() }),
+  body: refineDateRange(
+    z.object({
+      name: z.string().min(1).max(255).optional(),
+      policyNumber: z.string().max(100).optional().nullable(),
+      provider: z.string().min(1).max(255).optional(),
+      type: z.enum(["group_health", "group_life", "disability", "accidental", "travel"]).optional(),
+      premiumTotal: z.number().min(0).optional(),
+      premiumPerEmployee: z.number().min(0).optional(),
+      coverageAmount: z.number().min(0).optional(),
+      startDate: z.string().optional(),
+      endDate: z.string().optional().nullable(),
+      renewalDate: z.string().optional().nullable(),
+      documentUrl: z.string().optional().nullable(),
+      terms: z.string().optional().nullable(),
+      status: z.enum(["active", "expired", "cancelled"]).optional(),
+    }),
+    "startDate",
+    "endDate",
+    "Policy",
+  ),
 });
 
 export const enrollInsuranceSchema = z.object({

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -333,6 +333,20 @@ export const createBenchmarkSchema = z.object({
   }),
 });
 
+export const updateBenchmarkSchema = z.object({
+  params: z.object({ id: z.string() }),
+  body: z.object({
+    jobTitle: z.string().min(1).max(255).optional(),
+    department: z.string().max(100).optional().nullable(),
+    location: z.string().max(255).optional().nullable(),
+    marketP25: z.number().min(0).optional(),
+    marketP50: z.number().min(0).optional(),
+    marketP75: z.number().min(0).optional(),
+    source: z.string().max(255).optional().nullable(),
+    effectiveDate: z.string().optional(),
+  }),
+});
+
 export const importBenchmarksSchema = z.object({
   body: z.object({
     benchmarks: z

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -263,40 +263,96 @@ export const createOrgSchema = z.object({
 // ---------------------------------------------------------------------------
 // Benefits Schemas
 // ---------------------------------------------------------------------------
+// Reusable helper — guards any schema where both startKey and endKey are
+// optional date strings. Fails with a clear "end must be on or after start"
+// message so the UI can surface it inline. Shared by the benefit-plan /
+// benefit-enrollment schemas (both affected by #15) and reused by the
+// insurance schemas (#13).
+function refineDateRange<T extends z.ZodRawShape>(
+  shape: z.ZodObject<T>,
+  startKey: keyof T & string,
+  endKey: keyof T & string,
+  label: string,
+) {
+  return shape.refine(
+    (v: any) => {
+      if (!v[startKey] || !v[endKey]) return true;
+      return new Date(v[endKey]).getTime() >= new Date(v[startKey]).getTime();
+    },
+    {
+      message: `${label} end date must be on or after start date`,
+      path: [endKey],
+    },
+  );
+}
+
 export const createBenefitPlanSchema = z.object({
-  body: z.object({
-    name: z.string().min(1).max(100),
-    type: z.enum(["health", "dental", "vision", "life", "disability", "retirement"]),
-    provider: z.string().max(255).optional(),
-    description: z.string().optional(),
-    premiumAmount: z.number().min(0).default(0),
-    employerContribution: z.number().min(0).default(0),
-    coverageDetails: z.record(z.any()).optional(),
-    enrollmentPeriodStart: z.string().optional(),
-    enrollmentPeriodEnd: z.string().optional(),
-  }),
+  body: refineDateRange(
+    z.object({
+      name: z.string().min(1).max(100),
+      type: z.enum(["health", "dental", "vision", "life", "disability", "retirement"]),
+      provider: z.string().max(255).optional(),
+      description: z.string().optional(),
+      premiumAmount: z.number().min(0).default(0),
+      employerContribution: z.number().min(0).default(0),
+      coverageDetails: z.record(z.any()).optional(),
+      enrollmentPeriodStart: z.string().optional(),
+      enrollmentPeriodEnd: z.string().optional(),
+    }),
+    "enrollmentPeriodStart",
+    "enrollmentPeriodEnd",
+    "Enrollment period",
+  ),
+});
+
+export const updateBenefitPlanSchema = z.object({
+  params: z.object({ id: z.string() }),
+  body: refineDateRange(
+    z.object({
+      name: z.string().min(1).max(100).optional(),
+      type: z.enum(["health", "dental", "vision", "life", "disability", "retirement"]).optional(),
+      provider: z.string().max(255).optional().nullable(),
+      description: z.string().optional().nullable(),
+      premiumAmount: z.number().min(0).optional(),
+      employerContribution: z.number().min(0).optional(),
+      coverageDetails: z.record(z.any()).optional(),
+      enrollmentPeriodStart: z.string().optional().nullable(),
+      enrollmentPeriodEnd: z.string().optional().nullable(),
+      isActive: z.boolean().optional(),
+    }),
+    "enrollmentPeriodStart",
+    "enrollmentPeriodEnd",
+    "Enrollment period",
+  ),
 });
 
 export const enrollBenefitSchema = z.object({
-  body: z.object({
-    employeeId: z.union([z.string(), z.number()]).transform(String),
-    planId: z.string(),
-    coverageType: z.enum(["individual", "family", "individual_plus_spouse"]).default("individual"),
-    startDate: z.string(),
-    endDate: z.string().optional(),
-    status: z.enum(["enrolled", "pending"]).default("pending"),
-    premiumEmployeeShare: z.number().min(0).default(0),
-    premiumEmployerShare: z.number().min(0).optional(),
-    dependents: z
-      .array(
-        z.object({
-          name: z.string().min(1).max(255),
-          relationship: z.enum(["spouse", "child", "parent"]),
-          dateOfBirth: z.string().optional(),
-        }),
-      )
-      .optional(),
-  }),
+  body: refineDateRange(
+    z.object({
+      employeeId: z.union([z.string(), z.number()]).transform(String),
+      planId: z.string(),
+      coverageType: z
+        .enum(["individual", "family", "individual_plus_spouse"])
+        .default("individual"),
+      startDate: z.string(),
+      endDate: z.string().optional(),
+      status: z.enum(["enrolled", "pending"]).default("pending"),
+      premiumEmployeeShare: z.number().min(0).default(0),
+      premiumEmployerShare: z.number().min(0).optional(),
+      dependents: z
+        .array(
+          z.object({
+            name: z.string().min(1).max(255),
+            relationship: z.enum(["spouse", "child", "parent"]),
+            dateOfBirth: z.string().optional(),
+          }),
+        )
+        .optional(),
+    }),
+    "startDate",
+    "endDate",
+    "Enrollment",
+  ),
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #14. Closes #13.

Mirror of #62 (same bugs, Insurance module instead of Benefits).

## #14 — Edit / Delete missing on Insurance policies
`policyColumns` rendered no actions cell — the UI had no way to edit or deactivate a policy even though `PUT /insurance/policies/:id` + `DELETE /insurance/policies/:id` had working service methods.

**Fix (client)**:
- Added a `Pencil` + `Trash2` button group in the policy row. Pencil sets `editingPolicy` state and re-purposes the existing Create Policy modal — title flips to *Edit Insurance Policy*, inputs pre-fill from the row (`policy_number`, `premium_total`, etc.), submit label becomes *Update Policy*, and the handler calls `apiPut` vs `apiPost` based on the state.
- `Trash2` calls `DELETE /insurance/policies/:id` after a confirm. Hidden once the policy's `status !== "active"`.

**Fix (server)**:
- Added `updateInsurancePolicySchema` (all fields optional, same types as create) and wired it via `validate(...)` on the PUT route. Previously the route had no validator.

## #13 — Policy end date before start date
`createInsurancePolicySchema` had `startDate` (required) and `endDate` (optional) but no cross-field check, so a policy could be saved with end < start. Same on the (missing) update schema.

**Fix (server)**:
- Wrapped both `createInsurancePolicySchema` and `updateInsurancePolicySchema` with the `refineDateRange` helper (introduced in #62 for the Benefits duplicate). Returns 400 *"Policy end date must be on or after start date"* with `path: ["endDate"]`.

**Fix (client)**:
- Pre-submit guard in the Create / Edit Policy form — toasts *"Policy end date cannot be before start date"* and early-returns before the API call.
- When the start date is picked, the end date input's `min` is updated so the native date picker blocks earlier selections in the first place.
- Numeric fields (`premiumTotal`, `premiumPerEmployee`, `coverageAmount`) got `min={0}` while we were in the modal.

## Files
- `packages/client/src/pages/insurance/InsurancePage.tsx`
- `packages/server/src/api/routes/insurance.routes.ts`
- `packages/server/src/api/validators/index.ts`

## Test plan
- [x] Policies row shows Pencil + Trash2.
- [x] Pencil → modal opens pre-filled → change a field → *Update Policy* → row reflects changes.
- [x] Trash2 → confirm → status flips to non-active, trash disappears from that row.
- [x] Create a policy with `endDate < startDate` via curl → 400 with the cross-field message.
- [x] Same via the form → toast shown, no request fired.
- [x] Selecting a start date updates the end input's `min` so the native picker refuses earlier dates.
- [x] `pnpm --filter @emp-payroll/server exec tsc --noEmit` and `--filter @emp-payroll/client` both pass.