### PR TITLE
fix(leaves): load leave types from EmpCloud instead of hardcoded codes

### DIFF
--- a/packages/client/src/pages/self-service/MyLeavesPage.tsx
+++ b/packages/client/src/pages/self-service/MyLeavesPage.tsx
@@ -12,13 +12,6 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, Calendar, Loader2, X, Check, Users } from "lucide-react";
 import toast from "react-hot-toast";
 
-const LEAVE_TYPES = [
-  { value: "earned", label: "Earned Leave" },
-  { value: "casual", label: "Casual Leave" },
-  { value: "sick", label: "Sick Leave" },
-  { value: "comp_off", label: "Compensatory Off" },
-];
-
 const STATUS_COLORS: Record<string, "green" | "yellow" | "red" | "gray"> = {
   pending: "yellow",
   approved: "green",
@@ -34,7 +27,10 @@ export function MyLeavesPage() {
   const [filter, setFilter] = useState("all");
   const [tab, setTab] = useState<"my" | "team">("my");
   const [teamFilter, setTeamFilter] = useState("pending");
-  const [remarksModal, setRemarksModal] = useState<{ id: string; action: "approve" | "reject" } | null>(null);
+  const [remarksModal, setRemarksModal] = useState<{
+    id: string;
+    action: "approve" | "reject";
+  } | null>(null);
   const [remarks, setRemarks] = useState("");
   const qc = useQueryClient();
 
@@ -42,6 +38,19 @@ export function MyLeavesPage() {
     queryKey: ["my-leave-balance"],
     queryFn: () => apiGet<any>("/leaves/my-balance"),
   });
+
+  // Fetch leave types from EmpCloud instead of hardcoding them (#12).
+  // The previous hardcoded {earned, casual, sick, comp_off} values never
+  // matched what leave_types.code actually held in the DB (CL / SL / EL),
+  // so every Apply Leave attempt 400'd with 'Leave type not found'.
+  const { data: typesData } = useQuery({
+    queryKey: ["leave-types"],
+    queryFn: () => apiGet<any>("/leaves/types"),
+  });
+  const leaveTypeOptions = (typesData?.data || []).map((t: any) => ({
+    value: t.code,
+    label: t.name,
+  }));
 
   const { data: requestsData, isLoading: reqLoading } = useQuery({
     queryKey: ["my-leave-requests", filter],
@@ -51,7 +60,8 @@ export function MyLeavesPage() {
   // Team leaves (direct reports) — fetched for everyone, empty if no reports
   const { data: teamData, isLoading: teamLoading } = useQuery({
     queryKey: ["team-leave-requests", teamFilter],
-    queryFn: () => apiGet<any>(`/leaves/team${teamFilter !== "all" ? `?status=${teamFilter}` : ""}`),
+    queryFn: () =>
+      apiGet<any>(`/leaves/team${teamFilter !== "all" ? `?status=${teamFilter}` : ""}`),
   });
 
   const balances = balanceData?.data?.data || [];
@@ -147,7 +157,9 @@ export function MyLeavesPage() {
           <button
             onClick={() => setTab("my")}
             className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
-              tab === "my" ? "bg-white shadow dark:bg-gray-700 dark:text-white" : "text-gray-500 hover:text-gray-700"
+              tab === "my"
+                ? "bg-white shadow dark:bg-gray-700 dark:text-white"
+                : "text-gray-500 hover:text-gray-700"
             }`}
           >
             <Calendar className="mr-1.5 inline h-4 w-4" /> My Leaves
@@ -155,7 +167,9 @@ export function MyLeavesPage() {
           <button
             onClick={() => setTab("team")}
             className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
-              tab === "team" ? "bg-white shadow dark:bg-gray-700 dark:text-white" : "text-gray-500 hover:text-gray-700"
+              tab === "team"
+                ? "bg-white shadow dark:bg-gray-700 dark:text-white"
+                : "text-gray-500 hover:text-gray-700"
             }`}
           >
             <Users className="mr-1.5 inline h-4 w-4" /> Team Leaves
@@ -187,7 +201,9 @@ export function MyLeavesPage() {
             {balances.map((b: any) => (
               <Card key={b.leave_type}>
                 <CardContent className="p-4 text-center">
-                  <p className="text-sm text-gray-500 dark:text-gray-400 capitalize">{b.leave_type.replace("_", " ")}</p>
+                  <p className="text-sm capitalize text-gray-500 dark:text-gray-400">
+                    {b.leave_type.replace("_", " ")}
+                  </p>
                   <p className="text-2xl font-bold">{Number(b.closing_balance)}</p>
                   <p className="text-xs text-gray-400">of {Number(b.accrued)}</p>
                 </CardContent>
@@ -198,7 +214,12 @@ export function MyLeavesPage() {
           {/* Filter */}
           <div className="flex items-center gap-2">
             {["all", "pending", "approved", "rejected", "cancelled"].map((s) => (
-              <Button key={s} variant={filter === s ? "primary" : "outline"} size="sm" onClick={() => setFilter(s)}>
+              <Button
+                key={s}
+                variant={filter === s ? "primary" : "outline"}
+                size="sm"
+                onClick={() => setFilter(s)}
+              >
                 {s.charAt(0).toUpperCase() + s.slice(1)}
               </Button>
             ))}
@@ -206,10 +227,14 @@ export function MyLeavesPage() {
 
           {/* My Requests Table */}
           <Card>
-            <CardHeader><CardTitle>Leave Requests</CardTitle></CardHeader>
+            <CardHeader>
+              <CardTitle>Leave Requests</CardTitle>
+            </CardHeader>
             <CardContent>
               {reqLoading ? (
-                <div className="flex justify-center py-8"><Loader2 className="h-6 w-6 animate-spin" /></div>
+                <div className="flex justify-center py-8">
+                  <Loader2 className="h-6 w-6 animate-spin" />
+                </div>
               ) : requests.length === 0 ? (
                 <div className="py-8 text-center text-gray-500">
                   <Calendar className="mx-auto mb-2 h-10 w-10 text-gray-300" />
@@ -218,32 +243,80 @@ export function MyLeavesPage() {
               ) : (
                 <DataTable
                   columns={[
-                    { key: "leave_type", header: "Type", render: (r: any) => (
-                      <span className="capitalize font-medium">{r.leave_type.replace("_", " ")}</span>
-                    )},
-                    { key: "start_date", header: "From", render: (r: any) => new Date(r.start_date).toLocaleDateString("en-IN") },
-                    { key: "end_date", header: "To", render: (r: any) => new Date(r.end_date).toLocaleDateString("en-IN") },
-                    { key: "days", header: "Days", render: (r: any) => (
-                      <span>{Number(r.days)}{r.is_half_day ? " (Half)" : ""}</span>
-                    )},
-                    { key: "reason", header: "Reason", render: (r: any) => (
-                      <span className="max-w-[200px] truncate block">{r.reason}</span>
-                    )},
-                    { key: "assigned_to", header: "Approver", render: (r: any) => (
-                      <span className="text-sm text-gray-500">{r.assignedToName || "HR Admin"}</span>
-                    )},
-                    { key: "status", header: "Status", render: (r: any) => (
-                      <Badge variant={STATUS_COLORS[r.status] || "gray"}>{r.status}</Badge>
-                    )},
-                    { key: "actions", header: "", render: (r: any) => (
-                      (r.status === "pending" || r.status === "approved") ? (
-                        <Button variant="ghost" size="sm" onClick={() => { setShowCancel(r.id); setCancelReason(""); }} title="Cancel leave">
-                          <X className="h-4 w-4 text-red-500" />
-                        </Button>
-                      ) : r.cancellation_reason ? (
-                        <span className="text-xs text-gray-400 italic">Cancelled: {r.cancellation_reason}</span>
-                      ) : null
-                    )},
+                    {
+                      key: "leave_type",
+                      header: "Type",
+                      render: (r: any) => (
+                        <span className="font-medium capitalize">
+                          {r.leave_type.replace("_", " ")}
+                        </span>
+                      ),
+                    },
+                    {
+                      key: "start_date",
+                      header: "From",
+                      render: (r: any) => new Date(r.start_date).toLocaleDateString("en-IN"),
+                    },
+                    {
+                      key: "end_date",
+                      header: "To",
+                      render: (r: any) => new Date(r.end_date).toLocaleDateString("en-IN"),
+                    },
+                    {
+                      key: "days",
+                      header: "Days",
+                      render: (r: any) => (
+                        <span>
+                          {Number(r.days)}
+                          {r.is_half_day ? " (Half)" : ""}
+                        </span>
+                      ),
+                    },
+                    {
+                      key: "reason",
+                      header: "Reason",
+                      render: (r: any) => (
+                        <span className="block max-w-[200px] truncate">{r.reason}</span>
+                      ),
+                    },
+                    {
+                      key: "assigned_to",
+                      header: "Approver",
+                      render: (r: any) => (
+                        <span className="text-sm text-gray-500">
+                          {r.assignedToName || "HR Admin"}
+                        </span>
+                      ),
+                    },
+                    {
+                      key: "status",
+                      header: "Status",
+                      render: (r: any) => (
+                        <Badge variant={STATUS_COLORS[r.status] || "gray"}>{r.status}</Badge>
+                      ),
+                    },
+                    {
+                      key: "actions",
+                      header: "",
+                      render: (r: any) =>
+                        r.status === "pending" || r.status === "approved" ? (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => {
+                              setShowCancel(r.id);
+                              setCancelReason("");
+                            }}
+                            title="Cancel leave"
+                          >
+                            <X className="h-4 w-4 text-red-500" />
+                          </Button>
+                        ) : r.cancellation_reason ? (
+                          <span className="text-xs italic text-gray-400">
+                            Cancelled: {r.cancellation_reason}
+                          </span>
+                        ) : null,
+                    },
                   ]}
                   data={requests}
                 />
@@ -256,17 +329,26 @@ export function MyLeavesPage() {
           {/* TEAM LEAVES TAB */}
           <div className="flex items-center gap-2">
             {["all", "pending", "approved", "rejected", "cancelled"].map((s) => (
-              <Button key={s} variant={teamFilter === s ? "primary" : "outline"} size="sm" onClick={() => setTeamFilter(s)}>
+              <Button
+                key={s}
+                variant={teamFilter === s ? "primary" : "outline"}
+                size="sm"
+                onClick={() => setTeamFilter(s)}
+              >
                 {s.charAt(0).toUpperCase() + s.slice(1)}
               </Button>
             ))}
           </div>
 
           <Card>
-            <CardHeader><CardTitle>Team Leave Requests (Direct Reports)</CardTitle></CardHeader>
+            <CardHeader>
+              <CardTitle>Team Leave Requests (Direct Reports)</CardTitle>
+            </CardHeader>
             <CardContent>
               {teamLoading ? (
-                <div className="flex justify-center py-8"><Loader2 className="h-6 w-6 animate-spin" /></div>
+                <div className="flex justify-center py-8">
+                  <Loader2 className="h-6 w-6 animate-spin" />
+                </div>
               ) : teamRequests.length === 0 ? (
                 <div className="py-8 text-center text-gray-500">
                   <Users className="mx-auto mb-2 h-10 w-10 text-gray-300" />
@@ -275,40 +357,89 @@ export function MyLeavesPage() {
               ) : (
                 <DataTable
                   columns={[
-                    { key: "employeeName", header: "Employee", render: (r: any) => (
-                      <div>
-                        <p className="font-medium">{r.employeeName}</p>
-                        <p className="text-xs text-gray-500">{r.employeeCode} · {r.department}</p>
-                      </div>
-                    )},
-                    { key: "leave_type", header: "Type", render: (r: any) => (
-                      <span className="capitalize">{r.leave_type.replace("_", " ")}</span>
-                    )},
-                    { key: "start_date", header: "From", render: (r: any) => new Date(r.start_date).toLocaleDateString("en-IN") },
-                    { key: "end_date", header: "To", render: (r: any) => new Date(r.end_date).toLocaleDateString("en-IN") },
-                    { key: "days", header: "Days", render: (r: any) => (
-                      <span className="font-medium">{Number(r.days)}{r.is_half_day ? " (Half)" : ""}</span>
-                    )},
-                    { key: "reason", header: "Reason", render: (r: any) => (
-                      <span className="max-w-[200px] truncate block text-sm">{r.reason}</span>
-                    )},
-                    { key: "status", header: "Status", render: (r: any) => (
-                      <Badge variant={STATUS_COLORS[r.status] || "gray"}>{r.status}</Badge>
-                    )},
-                    { key: "actions", header: "Actions", render: (r: any) => (
-                      r.status === "pending" ? (
-                        <div className="flex gap-1">
-                          <Button variant="ghost" size="sm" onClick={() => quickApprove(r.id)} title="Approve">
-                            <Check className="h-4 w-4 text-green-600" />
-                          </Button>
-                          <Button variant="ghost" size="sm" onClick={() => { setRemarksModal({ id: r.id, action: "reject" }); setRemarks(""); }} title="Reject">
-                            <X className="h-4 w-4 text-red-600" />
-                          </Button>
+                    {
+                      key: "employeeName",
+                      header: "Employee",
+                      render: (r: any) => (
+                        <div>
+                          <p className="font-medium">{r.employeeName}</p>
+                          <p className="text-xs text-gray-500">
+                            {r.employeeCode} · {r.department}
+                          </p>
                         </div>
-                      ) : r.approver_remarks ? (
-                        <span className="text-xs text-gray-500 italic">{r.approver_remarks}</span>
-                      ) : null
-                    )},
+                      ),
+                    },
+                    {
+                      key: "leave_type",
+                      header: "Type",
+                      render: (r: any) => (
+                        <span className="capitalize">{r.leave_type.replace("_", " ")}</span>
+                      ),
+                    },
+                    {
+                      key: "start_date",
+                      header: "From",
+                      render: (r: any) => new Date(r.start_date).toLocaleDateString("en-IN"),
+                    },
+                    {
+                      key: "end_date",
+                      header: "To",
+                      render: (r: any) => new Date(r.end_date).toLocaleDateString("en-IN"),
+                    },
+                    {
+                      key: "days",
+                      header: "Days",
+                      render: (r: any) => (
+                        <span className="font-medium">
+                          {Number(r.days)}
+                          {r.is_half_day ? " (Half)" : ""}
+                        </span>
+                      ),
+                    },
+                    {
+                      key: "reason",
+                      header: "Reason",
+                      render: (r: any) => (
+                        <span className="block max-w-[200px] truncate text-sm">{r.reason}</span>
+                      ),
+                    },
+                    {
+                      key: "status",
+                      header: "Status",
+                      render: (r: any) => (
+                        <Badge variant={STATUS_COLORS[r.status] || "gray"}>{r.status}</Badge>
+                      ),
+                    },
+                    {
+                      key: "actions",
+                      header: "Actions",
+                      render: (r: any) =>
+                        r.status === "pending" ? (
+                          <div className="flex gap-1">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => quickApprove(r.id)}
+                              title="Approve"
+                            >
+                              <Check className="h-4 w-4 text-green-600" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => {
+                                setRemarksModal({ id: r.id, action: "reject" });
+                                setRemarks("");
+                              }}
+                              title="Reject"
+                            >
+                              <X className="h-4 w-4 text-red-600" />
+                            </Button>
+                          </div>
+                        ) : r.approver_remarks ? (
+                          <span className="text-xs italic text-gray-500">{r.approver_remarks}</span>
+                        ) : null,
+                    },
                   ]}
                   data={teamRequests}
                 />
@@ -321,29 +452,49 @@ export function MyLeavesPage() {
       {/* Apply Leave Modal */}
       <Modal open={showApply} onClose={() => setShowApply(false)} title="Apply for Leave">
         <form onSubmit={handleApply} className="space-y-4">
-          <SelectField id="leaveType" name="leaveType" label="Leave Type" required
-            options={[{ value: "", label: "Select type..." }, ...LEAVE_TYPES]}
+          <SelectField
+            id="leaveType"
+            name="leaveType"
+            label="Leave Type"
+            required
+            options={[{ value: "", label: "Select type..." }, ...leaveTypeOptions]}
           />
           <div className="grid grid-cols-2 gap-4">
             <Input id="startDate" name="startDate" label="Start Date" type="date" required />
             <Input id="endDate" name="endDate" label="End Date" type="date" required />
           </div>
-          <SelectField id="isHalfDay" name="isHalfDay" label="Half Day?"
+          <SelectField
+            id="isHalfDay"
+            name="isHalfDay"
+            label="Half Day?"
             options={[
               { value: "false", label: "No — Full Day(s)" },
               { value: "true", label: "Yes — Half Day" },
             ]}
           />
           <div>
-            <label htmlFor="reason" className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Reason</label>
-            <textarea id="reason" name="reason" required rows={3}
+            <label
+              htmlFor="reason"
+              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Reason
+            </label>
+            <textarea
+              id="reason"
+              name="reason"
+              required
+              rows={3}
               className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
               placeholder="Reason for leave..."
             />
           </div>
-          <p className="text-xs text-gray-500">Your leave request will be sent to your reporting manager for approval.</p>
+          <p className="text-xs text-gray-500">
+            Your leave request will be sent to your reporting manager for approval.
+          </p>
           <div className="flex justify-end gap-2">
-            <Button variant="outline" type="button" onClick={() => setShowApply(false)}>Cancel</Button>
+            <Button variant="outline" type="button" onClick={() => setShowApply(false)}>
+              Cancel
+            </Button>
             <Button type="submit" disabled={submitting}>
               {submitting ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
               Submit
@@ -356,18 +507,35 @@ export function MyLeavesPage() {
       <Modal open={!!showCancel} onClose={() => setShowCancel(null)} title="Cancel Leave">
         <div className="space-y-4">
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            Are you sure you want to cancel this leave? If already approved, your balance will be restored.
+            Are you sure you want to cancel this leave? If already approved, your balance will be
+            restored.
           </p>
           <div>
-            <label htmlFor="cancelReason" className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Reason</label>
-            <textarea id="cancelReason" value={cancelReason} onChange={(e) => setCancelReason(e.target.value)} required rows={3}
+            <label
+              htmlFor="cancelReason"
+              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Reason
+            </label>
+            <textarea
+              id="cancelReason"
+              value={cancelReason}
+              onChange={(e) => setCancelReason(e.target.value)}
+              required
+              rows={3}
               className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
               placeholder="Why are you cancelling?"
             />
           </div>
           <div className="flex justify-end gap-2">
-            <Button variant="outline" onClick={() => setShowCancel(null)}>Go Back</Button>
-            <Button variant="danger" onClick={handleCancel} disabled={submitting || !cancelReason.trim()}>
+            <Button variant="outline" onClick={() => setShowCancel(null)}>
+              Go Back
+            </Button>
+            <Button
+              variant="danger"
+              onClick={handleCancel}
+              disabled={submitting || !cancelReason.trim()}
+            >
               {submitting ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
               Confirm Cancellation
             </Button>
@@ -376,18 +544,33 @@ export function MyLeavesPage() {
       </Modal>
 
       {/* Reject with Remarks Modal */}
-      <Modal open={!!remarksModal} onClose={() => setRemarksModal(null)} title={remarksModal?.action === "approve" ? "Approve Leave" : "Reject Leave"}>
+      <Modal
+        open={!!remarksModal}
+        onClose={() => setRemarksModal(null)}
+        title={remarksModal?.action === "approve" ? "Approve Leave" : "Reject Leave"}
+      >
         <div className="space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Remarks (optional)</label>
-            <textarea value={remarks} onChange={(e) => setRemarks(e.target.value)} rows={3}
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Remarks (optional)
+            </label>
+            <textarea
+              value={remarks}
+              onChange={(e) => setRemarks(e.target.value)}
+              rows={3}
               className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
               placeholder="Add remarks..."
             />
           </div>
           <div className="flex justify-end gap-2">
-            <Button variant="outline" onClick={() => setRemarksModal(null)}>Cancel</Button>
-            <Button variant={remarksModal?.action === "reject" ? "danger" : "primary"} onClick={handleTeamAction} disabled={submitting}>
+            <Button variant="outline" onClick={() => setRemarksModal(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant={remarksModal?.action === "reject" ? "danger" : "primary"}
+              onClick={handleTeamAction}
+              disabled={submitting}
+            >
               {submitting ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
               {remarksModal?.action === "approve" ? "Approve" : "Reject"}
             </Button>

--- a/packages/server/src/api/routes/leave.routes.ts
+++ b/packages/server/src/api/routes/leave.routes.ts
@@ -48,6 +48,17 @@ router.get(
   }),
 );
 
+// Active leave types for the caller's org — drives the Apply Leave dropdown
+// (#12). EmpCloud stores codes like CL / SL / EL; the client used to hardcode
+// casual / sick / earned, so every apply-leave attempt 400'd.
+router.get(
+  "/types",
+  wrap(async (req, res) => {
+    const data = await svc.listLeaveTypes(String(req.user!.empcloudOrgId));
+    res.json({ success: true, data });
+  }),
+);
+
 // Cancel leave (employee — immediate)
 router.post(
   "/:id/cancel",

--- a/packages/server/src/services/leave.service.ts
+++ b/packages/server/src/services/leave.service.ts
@@ -177,6 +177,17 @@ export class LeaveService {
 
   // -------------------------------------------------------------------------
   // Leave Actions — proxy to EmpCloud's leave_applications
+  // List active leave types for an org — used by the Apply Leave form so the
+  // dropdown shows the real codes/names instead of a hardcoded list that
+  // didn't match what EmpCloud stored (issue #12).
+  async listLeaveTypes(orgId: string) {
+    const empcloudDb = getEmpCloudDB();
+    return empcloudDb("leave_types")
+      .where({ organization_id: Number(orgId), is_active: true })
+      .select("id", "code", "name", "leave_category", "max_days_per_year")
+      .orderBy("name", "asc");
+  }
+
   // -------------------------------------------------------------------------
   async applyLeave(
     employeeId: string,


### PR DESCRIPTION
Closes #12.

## Root cause
`MyLeavesPage` rendered the Leave Type dropdown from a local constant:

```ts
const LEAVE_TYPES = [
  { value: "earned", label: "Earned Leave" },
  { value: "casual", label: "Casual Leave" },
  { value: "sick", label: "Sick Leave" },
  { value: "comp_off", label: "Compensatory Off" },
];
```

But `empcloud.leave_types.code` stores short abbreviations — for the local dev DB, `EL`, `CL`, `SL`. `LeaveService.applyLeave` does:

```ts
const leaveType = await empcloudDb("leave_types")
  .where({ organization_id, code: data.leaveType, is_active: true })
  .first();
if (!leaveType) throw new AppError(400, "INVALID_TYPE", `Leave type '${data.leaveType}' not found`);
```

Every hardcoded value missed, so every Apply Leave attempt 400'd with *"Leave type 'casual' not found"* etc. The flow was completely broken for every org.

## Fix
Load the dropdown options from EmpCloud so the client uses real codes:

### Server
- **New** `LeaveService.listLeaveTypes(orgId)` — queries `empcloud.leave_types` where `organization_id = orgId AND is_active = true`, returns `{ id, code, name, leave_category, max_days_per_year }`.
- **New route** `GET /api/v1/leaves/types` — authenticated, no role gate (every employee needs to see their own leave types to apply).

### Client
- `MyLeavesPage` now fetches `/leaves/types` via react-query and maps the response into the existing `SelectField`:
  ```ts
  const leaveTypeOptions = (typesData?.data || []).map((t) => ({ value: t.code, label: t.name }));
  ```
- Deleted the `LEAVE_TYPES` constant entirely.

No DB migration, no schema change.

## Test plan
- [x] Open Apply Leave modal → Leave Type dropdown shows the real configured types for the caller's org (e.g. *Casual Leave / Earned Leave / Sick Leave* with codes `CL / EL / SL`).
- [x] Select any option + fill dates + reason → submit → 201 Created, leave appears in the history.
- [x] Previously every submission 400'd with *"Leave type … not found"* — now works.
- [x] Orgs with different configured codes (e.g. longer abbreviations, new types) just work — nothing is hardcoded anymore.
- [x] `/leaves/types` requires auth (401 without a token).
- [x] `pnpm --filter @emp-payroll/server exec tsc --noEmit` and `--filter @emp-payroll/client` both pass.