### PR TITLE
fix(employees): reject numeric names and alphabetic phone numbers

### DIFF
--- a/packages/client/src/pages/employees/EmployeeCreatePage.tsx
+++ b/packages/client/src/pages/employees/EmployeeCreatePage.tsx
@@ -21,6 +21,11 @@ function todayISO() {
 // Pure numeric or any embedded digit is rejected.
 const BANK_NAME_REGEX = /^[\p{L}\s.,&-]+$/u;
 
+// Person name — letters, spaces, apostrophes, hyphens, periods. No digits. (#11)
+const PERSON_NAME_REGEX = /^[\p{L}\s.'-]+$/u;
+// Phone — digits, +, spaces, hyphens, parentheses. No alphabets. (#11)
+const PHONE_REGEX = /^[+\d][\d\s()-]{0,19}$/;
+
 export function EmployeeCreatePage() {
   const navigate = useNavigate();
   const mutation = useCreateEmployee();
@@ -47,6 +52,23 @@ export function EmployeeCreatePage() {
     const bankName = get("bank_name");
     if (bankName && !BANK_NAME_REGEX.test(bankName)) {
       toast.error("Bank name must only contain letters, spaces, and . , & -");
+      return;
+    }
+
+    // Name + phone validation — mirrors the server schemas so we fail fast (#11).
+    const firstName = get("first_name");
+    const lastName = get("last_name");
+    if (firstName && !PERSON_NAME_REGEX.test(firstName)) {
+      toast.error("First name must not contain numbers or special characters");
+      return;
+    }
+    if (lastName && !PERSON_NAME_REGEX.test(lastName)) {
+      toast.error("Last name must not contain numbers or special characters");
+      return;
+    }
+    const phone = get("phone");
+    if (phone && !PHONE_REGEX.test(phone)) {
+      toast.error("Phone must only contain digits, spaces, and + - ( )");
       return;
     }
 
@@ -112,6 +134,10 @@ export function EmployeeCreatePage() {
                 label="First Name"
                 placeholder="Arjun"
                 required
+                // HTML5 pattern only supports ASCII ranges; the handleSubmit
+                // guard uses \p{L} regex for full i18n coverage.
+                pattern="[A-Za-z\u00C0-\u024F\s.'\-]+"
+                title="Letters, spaces, apostrophes, hyphens and periods only"
               />
               <Input
                 id="last_name"
@@ -119,6 +145,8 @@ export function EmployeeCreatePage() {
                 label="Last Name"
                 placeholder="Sharma"
                 required
+                pattern="[A-Za-z\u00C0-\u024F\s.'\-]+"
+                title="Letters, spaces, apostrophes, hyphens and periods only"
               />
               <Input
                 id="email"
@@ -128,7 +156,14 @@ export function EmployeeCreatePage() {
                 placeholder="arjun@company.com"
                 required
               />
-              <Input id="phone" name="phone" label="Phone" placeholder="+91 98765 43210" />
+              <Input
+                id="phone"
+                name="phone"
+                label="Phone"
+                placeholder="+91 98765 43210"
+                pattern="[+0-9][0-9\s()\-]{0,19}"
+                title="Digits, spaces, + - ( ) only"
+              />
               <Input id="dob" name="dob" label="Date of Birth" type="date" max={maxDob} required />
               <SelectField
                 id="gender"

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -27,6 +27,34 @@ export function validate(schema: z.ZodObject<any> | z.ZodEffects<any>) {
 }
 
 // ---------------------------------------------------------------------------
+// Shared field schemas — defined here so they're in scope for every other
+// schema further down in the file. ES `const` is not hoisted, so order
+// matters: defining these below would fail at module load time.
+// ---------------------------------------------------------------------------
+
+// Person name (first / last) — letters (inc. accented / i18n), spaces,
+// apostrophes, hyphens, periods. Rejects digits and other symbols. (#11)
+const personNameRegex = /^[\p{L}\s.'-]+$/u;
+const firstNameSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .regex(personNameRegex, "First name must not contain numbers or special characters");
+const lastNameSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .regex(personNameRegex, "Last name must not contain numbers or special characters");
+
+// Phone — digits, +, spaces, hyphens, parentheses. Rejects alphabets. (#11)
+// Must start with a digit or + so leading letters / whitespace don't pass.
+const phoneRegex = /^[+\d][\d\s()-]{0,19}$/;
+const phoneSchema = z
+  .string()
+  .max(20)
+  .regex(phoneRegex, "Phone must only contain digits, spaces, and + - ( )");
+
+// ---------------------------------------------------------------------------
 // Auth Schemas
 // ---------------------------------------------------------------------------
 export const loginSchema = z.object({
@@ -40,8 +68,8 @@ export const registerSchema = z.object({
   body: z.object({
     email: z.string().email(),
     password: z.string().min(8),
-    firstName: z.string().min(1).max(100),
-    lastName: z.string().min(1).max(100),
+    firstName: firstNameSchema,
+    lastName: lastNameSchema,
     orgId: z.string().uuid().optional(),
   }),
 });
@@ -78,10 +106,10 @@ const bankNameSchema = z
 export const createEmployeeSchema = z.object({
   body: z.object({
     employeeCode: z.string().min(1).max(50).optional(),
-    firstName: z.string().min(1).max(100),
-    lastName: z.string().min(1).max(100),
+    firstName: firstNameSchema,
+    lastName: lastNameSchema,
     email: z.string().email(),
-    phone: z.string().max(20).optional(),
+    phone: phoneSchema.optional(),
     dateOfBirth: pastDateOfBirth,
     gender: z.enum(["male", "female", "other"]),
     dateOfJoining: z.string(),
@@ -128,9 +156,9 @@ export const updateBankDetailsSchema = z.object({
 export const updateEmployeeSchema = z.object({
   params: z.object({ id: z.string() }),
   body: z.object({
-    firstName: z.string().min(1).max(100).optional(),
-    lastName: z.string().min(1).max(100).optional(),
-    phone: z.string().max(20).optional(),
+    firstName: firstNameSchema.optional(),
+    lastName: lastNameSchema.optional(),
+    phone: phoneSchema.optional(),
     department: z.string().max(100).optional(),
     designation: z.string().max(100).optional(),
     reportingManagerId: z.string().uuid().nullable().optional(),
@@ -437,8 +465,8 @@ export const reviewInsuranceClaimSchema = z.object({
 // ---------------------------------------------------------------------------
 export const addGlobalEmployeeSchema = z.object({
   body: z.object({
-    firstName: z.string().min(1).max(100),
-    lastName: z.string().min(1).max(100),
+    firstName: firstNameSchema,
+    lastName: lastNameSchema,
     email: z.string().email(),
     countryId: z.string().min(1),
     employmentType: z.enum(["eor", "contractor", "direct_hire"]),
@@ -463,8 +491,8 @@ export const addGlobalEmployeeSchema = z.object({
 export const updateGlobalEmployeeSchema = z.object({
   params: z.object({ id: z.string() }),
   body: z.object({
-    firstName: z.string().min(1).max(100).optional(),
-    lastName: z.string().min(1).max(100).optional(),
+    firstName: firstNameSchema.optional(),
+    lastName: lastNameSchema.optional(),
     email: z.string().email().optional(),
     countryId: z.string().optional(),
     employmentType: z.enum(["eor", "contractor", "direct_hire"]).optional(),


### PR DESCRIPTION
Closes #11.

## Root cause
The Employee Name and Phone fields had no character-class validation anywhere — client, server, or DB. A user could save:

```
firstName = '1234'
lastName  = '@@@'
phone     = 'hello'
```

and the server would persist whatever came in. Both `createEmployeeSchema` and `updateEmployeeSchema` typed these as bare `z.string().min(1).max(100)` / `.max(20)`.

## Fix

### Server — new shared schemas (`validators/index.ts`)
Defined at the top of the file so they're in scope for every other schema below (ES `const` is not hoisted):

- `firstNameSchema` / `lastNameSchema` — `/^[\p{L}\s.'-]+$/u`. Accepts letters (inc. accented / i18n), spaces, apostrophes, hyphens, periods. Rejects digits and other symbols.
- `phoneSchema` — `/^[+\d][\d\s()-]{0,19}$/`. Must start with a digit or `+`, then digits / spaces / `-` / `(` / `)` up to 20 chars total.

These replace the bare `z.string()` entries in every schema that accepted a name or phone:

| Schema | Fields tightened |
|---|---|
| `registerSchema` | `firstName`, `lastName` |
| `createEmployeeSchema` | `firstName`, `lastName`, `phone` |
| `updateEmployeeSchema` | `firstName`, `lastName`, `phone` |
| `addGlobalEmployeeSchema` | `firstName`, `lastName` |
| `updateGlobalEmployeeSchema` | `firstName`, `lastName` |

Server-side curl callers now get 400 `VALIDATION_ERROR` with a clear per-field message.

### Client — `EmployeeCreatePage.tsx`
- Pre-submit `handleSubmit` check mirrors the server regexes and toasts a specific error per field (same UX as the existing DOB / bank-name guards already on this page).
- HTML5 `pattern='...'` + `title='...'` added to the first name, last name and phone `Input` elements so the browser refuses invalid entries at submit time — no round-trip needed for the common bad-paste case.
- HTML5 patterns don't support `\p{L}`, so the inline pattern covers `A-Za-z` plus Latin-Extended accents (`\u00C0-\u024F`). Full i18n coverage lives in the JS `PERSON_NAME_REGEX`.

## Test plan
- [x] Add Employee → first name = `Arjun2` → browser-level error + toast + no request fired.
- [x] Add Employee → last name = `O'Brien` → passes (apostrophe allowed).
- [x] Add Employee → phone = `+91 98765 43210` → passes.
- [x] Add Employee → phone = `nine eight seven...` → blocked.
- [x] `curl POST /employees -d '{...firstName:"1234"...}'` → 400 with `First name must not contain numbers or special characters`.
- [x] `curl POST /employees -d '{...phone:"hello"...}'` → 400 with `Phone must only contain digits, spaces, and + - ( )`.
- [x] `curl POST /auth/register` with numeric names also rejected (register path uses the shared schemas).
- [x] `pnpm --filter @emp-payroll/server exec tsc --noEmit` and `--filter @emp-payroll/client` both pass.