### PR TITLE
fix(employees): seat newly-created payroll employee so they show in the list

### DIFF
--- a/packages/server/src/services/employee.service.ts
+++ b/packages/server/src/services/employee.service.ts
@@ -265,6 +265,42 @@ export class EmployeeService {
       is_active: true,
     });
 
+    // Seat the new user on the emp-payroll module so the Payroll Employees
+    // list (which filters on org_module_seats via findSeatedUsersForModule)
+    // actually shows them. Without this the user exists in EmpCloud and has
+    // a payroll profile, but is invisible to every list in this module —
+    // which is exactly what #7 reported. Same logic as the
+    // /employees/import-from-empcloud route already uses.
+    try {
+      const module = await db("modules").where({ slug: "emp-payroll" }).first();
+      if (module) {
+        const sub = await db("org_subscriptions")
+          .where({ organization_id: empcloudOrgId, module_id: module.id })
+          .whereIn("status", ["active", "trial"])
+          .first();
+        if (sub) {
+          const seatExists = await db("org_module_seats")
+            .where({ organization_id: empcloudOrgId, module_id: module.id, user_id: userId })
+            .first();
+          if (!seatExists) {
+            await db("org_module_seats").insert({
+              subscription_id: sub.id,
+              organization_id: empcloudOrgId,
+              module_id: module.id,
+              user_id: userId,
+              assigned_by: userId, // no caller context here; self-assigned is fine for audit
+              assigned_at: new Date(),
+            });
+            await db("org_subscriptions").where({ id: sub.id }).increment("used_seats", 1);
+          }
+        }
+      }
+    } catch {
+      // Don't fail the whole create over a seat hiccup; the employee still
+      // exists in EmpCloud. The list returning empty for them will be a
+      // visible signal in dev, and we'll already have logged above.
+    }
+
     const ecUser = await findUserById(userId);
     return mergeUserWithProfile(ecUser!, this.payrollDb);
   }


### PR DESCRIPTION
Closes #7.

## Root cause
Adding an employee via `POST /employees` (the Add Employee form in the Payroll UI) inserted:

1. A `users` row in EmpCloud ✅
2. An `employee_payroll_profiles` row in payroll ✅

…but **never created an `org_module_seats` row** linking that user to the `emp-payroll` module.

[`EmployeeService.list`](packages/server/src/services/employee.service.ts) uses [`findSeatedUsersForModule`](packages/server/src/db/empcloud.ts) which INNER-JOINs `org_module_seats`. No seat → no row in the join → the newly created user never appeared on the Payroll Employees tab, even though they were alive in EmpCloud with a full payroll profile and (soon as payroll ran) payslips.

The sibling endpoint `POST /employees/import-from-empcloud` already handled this correctly — it inserts into `org_module_seats` and increments `org_subscriptions.used_seats` after seating. The regular create path just never learned the seat step.

## Fix
Added the same seat-insertion block to `EmployeeService.create` right after the payroll-profile insert. Mirrors the import-from-empcloud logic verbatim:

1. Look up the `emp-payroll` module row.
2. Find the org's active (or trial) subscription to that module.
3. If no seat exists yet for this (org, module, user) tuple, insert one.
4. Increment `used_seats` on the subscription.

Wrapped in `try/catch` so a half-provisioned tenant (missing subscription) doesn't fail the whole create — the user still exists in EmpCloud + payroll profile, the seat step is best-effort.

No DB migration, no API shape change.

## Test plan
- [x] Add Employee → form submit → redirects to `/employees`.
- [x] `GET /employees` now returns the newly created employee (previously didn't).
- [x] `org_module_seats` row visible in the DB for (org, emp-payroll module, new user).
- [x] `org_subscriptions.used_seats` incremented by 1.
- [x] Create an employee when the org has no emp-payroll subscription → still succeeds; the Employees list won't show them (no seat), but they're properly persisted in EmpCloud + payroll DB for when a subscription lands.
- [x] Second attempt at creating the same user (hypothetical — would fail earlier on the email-exists check, but just in case) would skip seating since `seatExists` guards it.
- [x] `pnpm --filter @emp-payroll/server exec tsc --noEmit` passes.