### PR TITLE
fix(ui): three small dashboard/layout bugs (#39, #52, #42)

### DIFF
--- a/packages/client/src/components/layout/DashboardLayout.tsx
+++ b/packages/client/src/components/layout/DashboardLayout.tsx
@@ -22,12 +22,20 @@ export function DashboardLayout() {
 
   if (!isLoggedIn()) return <Navigate to="/login" replace />;
   const displayName = user ? `${user.firstName} ${user.lastName}` : "User";
+  // Map the 5 internal roles to human labels. Previously this only handled
+  // hr_admin / hr_manager and fell through to "Employee" for everything
+  // else — so org_admin + super_admin showed as "Employee" in the top bar
+  // (issue #39).
   const roleLabel =
-    user?.role === "hr_admin"
-      ? "HR Admin"
-      : user?.role === "hr_manager"
-        ? "HR Manager"
-        : "Employee";
+    user?.role === "super_admin"
+      ? "Super Admin"
+      : user?.role === "org_admin"
+        ? "Admin"
+        : user?.role === "hr_admin"
+          ? "HR Admin"
+          : user?.role === "hr_manager"
+            ? "HR Manager"
+            : "Employee";
 
   return (
     <div className="flex h-screen bg-gray-50">

--- a/packages/client/src/components/layout/Sidebar.tsx
+++ b/packages/client/src/components/layout/Sidebar.tsx
@@ -265,6 +265,14 @@ export function Sidebar() {
         {visibleItems.map((item) => {
           const showSection = item.section && item.section !== lastSection;
           if (item.section) lastSection = item.section;
+          // NavLink's default isActive matches any URL that starts with
+          // `to` + "/". So clicking /employees/org-chart also lit up the
+          // Employees entry ("/employees") — issue #42. Mark `end` on any
+          // item whose `to` is a prefix of another item's `to`, so the
+          // broader route only highlights on its exact match.
+          const hasMoreSpecificSibling = visibleItems.some(
+            (other) => other.to !== item.to && other.to.startsWith(item.to + "/"),
+          );
           return (
             <div key={item.to}>
               {showSection && (
@@ -274,7 +282,7 @@ export function Sidebar() {
               )}
               <NavLink
                 to={item.to}
-                end={item.to === "/my"}
+                end={item.to === "/my" || hasMoreSpecificSibling}
                 className={({ isActive }) =>
                   cn(
                     "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",

--- a/packages/client/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/client/src/pages/dashboard/DashboardPage.tsx
@@ -108,11 +108,14 @@ export function DashboardPage() {
         }
       />
 
-      {/* Quick actions */}
+      {/* Quick actions — the primary "Run Payroll" CTA lives in the page
+          header; this tile is relabelled to "Payroll Runs" so it's a
+          navigation shortcut to the runs history, not a duplicate action
+          (issue #52). */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-6">
         {[
           {
-            label: "Run Payroll",
+            label: "Payroll Runs",
             icon: Play,
             path: "/payroll/runs",
             color: "bg-brand-50 text-brand-700",


### PR DESCRIPTION
Bundled three tiny UI bugs that all touch `packages/client/src/components/layout` / dashboard — one PR keeps the review surface small.

## #39 — org_admin shown as *Employee* in the top-right
The `roleLabel` ternary in [DashboardLayout.tsx](packages/client/src/components/layout/DashboardLayout.tsx) only mapped `hr_admin` and `hr_manager`. Everything else — including `org_admin` and `super_admin` — fell through to *Employee*, so an org admin viewing the payroll dashboard saw `Employee` under their name.

**Fix**: explicit branches for `super_admin` → *Super Admin* and `org_admin` → *Admin*.

## #52 — two *Run Payroll* buttons on the dashboard
Both the `PageHeader` CTA and the Quick Actions tile said *Run Payroll* and both navigated to `/payroll/runs`.

**Fix**: kept the header CTA as the primary action. Renamed the Quick Actions tile to *Payroll Runs* so it reads as a navigation shortcut to the runs history instead of a duplicate action.

## #42 — Employees nav stays lit on Org Chart
The sidebar's `NavLink` used `end={item.to === "/my"}`, so `/my` was the only path with exact-match active state. React Router's default prefix matching highlighted `/employees` whenever any `/employees/*` URL (including Org Chart at `/employees/org-chart`) was active.

**Fix**: compute `hasMoreSpecificSibling` — any item whose `to` is a prefix of another visible item's `to` now gets `end={true}`, so the broader route only highlights on its exact path. Same pattern I used for the sidebar fix in EmpCloud (#1504).

## Test plan
- [x] Log in as org_admin → top-right shows *Admin* (was *Employee*).
- [x] Dashboard shows one *Run Payroll* button in the header; the Quick Actions tile now reads *Payroll Runs*.
- [x] Navigate to `/employees/org-chart` → only Org Chart nav item highlighted (Employees no longer glows).
- [x] Navigate to `/employees` → Employees nav item still highlighted as before.
- [x] Typecheck passes.