### PR TITLE
fix(analytics): render em-dash instead of NaN/Infinity in payroll analytics

### DIFF
--- a/packages/client/src/pages/payroll/PayrollAnalyticsPage.tsx
+++ b/packages/client/src/pages/payroll/PayrollAnalyticsPage.tsx
@@ -59,23 +59,35 @@ export function PayrollAnalyticsPage() {
     employerCost: Number(r.total_gross) + Number(r.total_employer_contributions || 0),
   }));
 
+  // Safe percent-of helper — returns null when the denominator is zero
+  // or non-finite so the caller can render a dash instead of Infinity/NaN.
+  // Issues #47 and #50: the first payroll run has no prior run, and when
+  // any run has total_gross = 0 the old inline math produced Infinity%
+  // in the summary cards and the per-row Gross%/Net% columns.
+  const safePct = (numerator: number, denominator: number): number | null => {
+    if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator === 0) {
+      return null;
+    }
+    return (numerator / denominator) * 100;
+  };
+
   // Calculate stats
   const latest = runs[runs.length - 1];
   const prev = runs[runs.length - 2];
   const grossChange =
     latest && prev
-      ? ((Number(latest.total_gross) - Number(prev.total_gross)) / Number(prev.total_gross)) * 100
-      : 0;
+      ? safePct(Number(latest.total_gross) - Number(prev.total_gross), Number(prev.total_gross))
+      : null;
   const netChange =
     latest && prev
-      ? ((Number(latest.total_net) - Number(prev.total_net)) / Number(prev.total_net)) * 100
-      : 0;
+      ? safePct(Number(latest.total_net) - Number(prev.total_net), Number(prev.total_net))
+      : null;
   const avgPerEmployee = latest
     ? Math.round(Number(latest.total_net) / (latest.employee_count || 1))
     : 0;
   const deductionRate = latest
-    ? Math.round((Number(latest.total_deductions) / Number(latest.total_gross)) * 100)
-    : 0;
+    ? safePct(Number(latest.total_deductions), Number(latest.total_gross))
+    : null;
 
   // Cost breakdown for latest
   const costBreakdown = latest
@@ -103,19 +115,21 @@ export function PayrollAnalyticsPage() {
         />
         <StatCard
           title="Gross Pay Change"
-          value={`${grossChange >= 0 ? "+" : ""}${grossChange.toFixed(1)}%`}
+          value={
+            grossChange === null ? "—" : `${grossChange >= 0 ? "+" : ""}${grossChange.toFixed(1)}%`
+          }
           subtitle="vs previous month"
-          icon={grossChange >= 0 ? TrendingUp : TrendingDown}
+          icon={(grossChange ?? 0) >= 0 ? TrendingUp : TrendingDown}
         />
         <StatCard
           title="Net Pay Change"
-          value={`${netChange >= 0 ? "+" : ""}${netChange.toFixed(1)}%`}
+          value={netChange === null ? "—" : `${netChange >= 0 ? "+" : ""}${netChange.toFixed(1)}%`}
           subtitle="vs previous month"
-          icon={netChange >= 0 ? TrendingUp : TrendingDown}
+          icon={(netChange ?? 0) >= 0 ? TrendingUp : TrendingDown}
         />
         <StatCard
           title="Deduction Rate"
-          value={`${deductionRate}%`}
+          value={deductionRate === null ? "—" : `${Math.round(deductionRate)}%`}
           subtitle="of gross pay"
           icon={Wallet}
         />
@@ -266,15 +280,19 @@ export function PayrollAnalyticsPage() {
                     .map((r: any, idx: number) => {
                       const reversed = runs.slice().reverse();
                       const prevRun = reversed[idx + 1];
+                      // Use safePct so a prev run with zero gross/net
+                      // renders "—" instead of Infinity/NaN (#47, #50).
                       const grossPct = prevRun
-                        ? ((Number(r.total_gross) - Number(prevRun.total_gross)) /
-                            Number(prevRun.total_gross)) *
-                          100
+                        ? safePct(
+                            Number(r.total_gross) - Number(prevRun.total_gross),
+                            Number(prevRun.total_gross),
+                          )
                         : null;
                       const netPct = prevRun
-                        ? ((Number(r.total_net) - Number(prevRun.total_net)) /
-                            Number(prevRun.total_net)) *
-                          100
+                        ? safePct(
+                            Number(r.total_net) - Number(prevRun.total_net),
+                            Number(prevRun.total_net),
+                          )
                         : null;
                       return (
                         <tr key={r.id} className="hover:bg-gray-50">


### PR DESCRIPTION
Closes #47. Closes #50.

## Root cause
The Payroll Analytics page computed percentage changes inline with plain division:

```ts
const grossChange = latest && prev
  ? ((Number(latest.total_gross) - Number(prev.total_gross)) / Number(prev.total_gross)) * 100
  : 0;
```

When `prev` is missing (first run has no prior), the guard catches it. But when `prev.total_gross` is zero (zeroed-out run) or when any `Number(...)` call returns `NaN` (null DB value), the division produced `Infinity` / `NaN` — which flowed into `.toFixed(1)` and rendered as `Infinity%` / `NaN%` in the UI.

Same bug appeared in two places on one page, each reported separately:
- The four summary stat cards at the top (Gross Change, Net Change, Deduction Rate)
- The per-row `Gross %` / `Net %` columns in the history table

## Fix
Introduced a small helper:

```ts
const safePct = (numerator: number, denominator: number): number | null => {
  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator === 0) {
    return null;
  }
  return (numerator / denominator) * 100;
};
```

Every percentage site (4 summary, 2 table columns) now uses it and renders `—` when the result is `null` instead of passing Infinity/NaN to `toFixed`. Also guarded the TrendingUp/TrendingDown icon choice on the summary cards so a null change doesn't accidentally render the red arrow.

## Test plan
- [x] With only one payroll run in the DB → summary shows *—* for Gross Change / Net Change / Deduction Rate (was *NaN%* / *Infinity%*).
- [x] With two runs where the prior run has `total_gross = 0` → summary and the newer row's `Gross %` cell show *—* (was *Infinity%*).
- [x] Normal case with two non-zero runs → percentages render as before (regression check).
- [x] Table rows that don't have a prior run still render *—* via the existing guard, unchanged.
- [x] `pnpm --filter @emp-payroll/client exec tsc --noEmit` passes.