### PR TITLE
fix(declarations): clear 400 when user not onboarded to payroll (#137)

### DIFF
--- a/packages/client/src/pages/self-service/MyDeclarationsPage.tsx
+++ b/packages/client/src/pages/self-service/MyDeclarationsPage.tsx
@@ -192,8 +192,16 @@ export function MyDeclarationsPage() {
       setShowAdd(false);
       qc.invalidateQueries({ queryKey: ["my-declarations"] });
     } catch (err: any) {
-      const msg =
-        err?.response?.data?.error?.message || err?.message || "Failed to submit declaration";
+      // #137 — surface server validation detail messages (e.g. per-field zod
+      // errors from the submitDeclarationSchema middleware) instead of just
+      // the generic top-level message, so the user can actually fix their input.
+      const resp = err?.response?.data?.error;
+      const detailMsgs = resp?.details
+        ? Object.values(resp.details as Record<string, string[]>)
+            .flat()
+            .join(", ")
+        : "";
+      const msg = detailMsgs || resp?.message || err?.message || "Failed to submit declaration";
       toast.error(msg);
     } finally {
       setSubmitting(false);

--- a/packages/server/src/api/routes/self-service.routes.ts
+++ b/packages/server/src/api/routes/self-service.routes.ts
@@ -1,7 +1,12 @@
 import { Router } from "express";
 import { authenticate } from "../middleware/auth.middleware";
 import { wrap, param } from "../helpers";
-import { validate, selfUpdateBankDetailsSchema, bankUpdateRequestSchema } from "../validators";
+import {
+  validate,
+  selfUpdateBankDetailsSchema,
+  bankUpdateRequestSchema,
+  submitDeclarationSchema,
+} from "../validators";
 import { EmployeeService } from "../../services/employee.service";
 import { SalaryService } from "../../services/salary.service";
 import { PayslipService } from "../../services/payslip.service";
@@ -139,6 +144,7 @@ router.get(
 
 router.post(
   "/tax/declarations",
+  validate(submitDeclarationSchema),
   wrap(async (req, res) => {
     const data = await taxSvc.submitDeclarations(
       uid(req),

--- a/packages/server/src/services/tax-declaration.service.ts
+++ b/packages/server/src/services/tax-declaration.service.ts
@@ -170,6 +170,19 @@ export class TaxDeclarationService {
     // employee_id must be a valid employees.id UUID, so we resolve it here.
     const { empcloudUserId, employeeRowId } = await this.resolveEmployeeIds(employeeId);
 
+    // #137 — When a user has logged in via SSO but isn't yet onboarded in the
+    // payroll `employees` table, employeeRowId is null. The FK is NOT NULL, so
+    // the insert below would fail with a cryptic DB error ("Column 'employee_id'
+    // cannot be null") surfaced to the client as a generic 500. Return a clear
+    // 400 so the admin knows this user needs to be added to payroll first.
+    if (!employeeRowId) {
+      throw new AppError(
+        400,
+        "EMPLOYEE_NOT_IN_PAYROLL",
+        "You don't have a payroll profile yet. Please ask your admin to add you to payroll before submitting declarations.",
+      );
+    }
+
     const results = [];
     for (const decl of normalized) {
       try {


### PR DESCRIPTION
Closes #137

## Root cause

Submit Declaration appeared to do nothing for any user who'd logged in via SSO but didn't have a matching row in the payroll `employees` table.

`resolveEmployeeIds` returns `{ employeeRowId: null }` when the authenticated EmpCloud user has no payroll profile. The subsequent insert into `tax_declarations` then failed on the NOT NULL + FK constraint for `employee_id`, producing a cryptic MySQL error (`Column 'employee_id' cannot be null`) surfaced to the client as a generic 500. From the user's perspective the button "wasn't working" — they saw an unhelpful toast and no progress.

## Changes

- **packages/server/src/services/tax-declaration.service.ts** — Throw a clear `400 EMPLOYEE_NOT_IN_PAYROLL` before attempting the insert when `employeeRowId` is null, with a message telling the user to ask their admin to add them to payroll.
- **packages/server/src/api/routes/self-service.routes.ts** — Added `validate(submitDeclarationSchema)` middleware to `POST /self-service/tax/declarations` so malformed payloads produce per-field zod errors. The admin route `/tax/declarations/:empId` already had this — the self-service route was missing it.
- **packages/client/src/pages/self-service/MyDeclarationsPage.tsx** — The single-declaration submit handler now surfaces `error.details` per-field messages in the toast (same pattern the wizard submit already uses), so server validation feedback actually reaches the user.

## Test plan
- [x] Submit a declaration as a user who has no payroll profile → toast shows the `EMPLOYEE_NOT_IN_PAYROLL` message instead of a silent fail or cryptic 500
- [x] Submit a valid declaration as a fully-onboarded user → declaration created, success toast, list refetches
- [x] Submit with a negative amount → per-field zod error appears in the toast (`declarations.0.declaredAmount: Number must be greater than 0`)
- [x] Both `tsc --noEmit` runs clean on client and server