### PR TITLE
fix(statcard): prevent large values from pushing icon out of card (#136)

### DIFF
--- a/packages/client/src/components/ui/StatCard.tsx
+++ b/packages/client/src/components/ui/StatCard.tsx
@@ -13,19 +13,28 @@ interface StatCardProps {
 export function StatCard({ title, value, subtitle, icon: Icon, trend, className }: StatCardProps) {
   return (
     <div className={cn("rounded-xl border border-gray-200 bg-white p-6 shadow-sm", className)}>
-      <div className="flex items-start justify-between">
-        <div className="space-y-1">
+      {/* #136 — min-w-0 on text column + shrink-0 on icon so large currency
+          values don't push the icon out of the card. break-words lets the
+          amount wrap to a second line instead of overflowing. */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-1">
           <p className="text-sm font-medium text-gray-500">{title}</p>
-          <p className="text-2xl font-bold text-gray-900">{value}</p>
+          <p className="break-words text-2xl font-bold text-gray-900">{value}</p>
           {subtitle && <p className="text-sm text-gray-500">{subtitle}</p>}
           {trend && (
-            <p className={cn("text-sm font-medium", trend.positive ? "text-green-600" : "text-red-600")}>
-              {trend.positive ? "+" : ""}{trend.value}
+            <p
+              className={cn(
+                "text-sm font-medium",
+                trend.positive ? "text-green-600" : "text-red-600",
+              )}
+            >
+              {trend.positive ? "+" : ""}
+              {trend.value}
             </p>
           )}
         </div>
-        <div className="rounded-lg bg-brand-50 p-3">
-          <Icon className="h-6 w-6 text-brand-600" />
+        <div className="bg-brand-50 shrink-0 rounded-lg p-3">
+          <Icon className="text-brand-600 h-6 w-6" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #136

## Root cause

When a currency value rendered into `StatCard` was long (e.g. `₹12,34,56,789`), the text column's `text-2xl font-bold` grew wider than its share of the flex parent. Because the icon chip sat in the same flex row without a `shrink-0` guard and the text column had no `min-w-0`, the icon got shoved outside the card's right edge.

Visible on **My Tax** (`MyTaxPage.tsx`) per the issue, but `StatCard` is used across My Salary, Dashboard stats, payslip summaries, etc. — the fix applies to all of them.

## Changes

`packages/client/src/components/ui/StatCard.tsx` — standard flex-truncate pattern:

- `min-w-0 flex-1` on the text column so it can shrink below its intrinsic width
- `shrink-0` on the icon wrapper so it never collapses or gets pushed out
- `gap-3` between the two columns so the wrap point has breathing room
- `break-words` on the value so a very long amount wraps onto a second line instead of overflowing horizontally

## Test plan
- [x] My Tax page with small values — icons stay aligned top-right
- [x] My Tax page with long amount (`₹99,99,99,999`) — value wraps to two lines, icon stays inside the card
- [x] `tsc --noEmit` clean