### PR TITLE
Batch fixes for issues #168-#177

### DIFF
--- a/packages/client/src/pages/benefits/BenefitsPage.tsx
+++ b/packages/client/src/pages/benefits/BenefitsPage.tsx
@@ -209,7 +209,11 @@ export function BenefitsPage() {
           >
             <Pencil className="h-4 w-4" />
           </Button>
-          {r.is_active && (
+          {/* #168 — MySQL tinyint(1) comes back as 0/1; `0 && <Button/>`
+              renders the literal "0" next to the pencil icon on inactive
+              rows. Coerce to a real boolean so React skips the falsy
+              branch cleanly instead of printing a stray digit. */}
+          {!!r.is_active && (
             <Button
               variant="ghost"
               size="sm"

--- a/packages/client/src/pages/earned-wage/EarnedWagePage.tsx
+++ b/packages/client/src/pages/earned-wage/EarnedWagePage.tsx
@@ -31,7 +31,13 @@ const STATUS_BADGE: Record<string, "active" | "draft" | "inactive"> = {
 };
 
 export function EarnedWagePage() {
-  const [tab, setTab] = useState<"requests" | "settings">("requests");
+  // #171 — Stat cards used to call setTab("requests") against a tab state
+  // that never changed anything because the Requests table was already the
+  // only content rendered. Replace with a statusFilter so clicking e.g.
+  // "Pending Requests" actually scopes the table to pending rows.
+  const [statusFilter, setStatusFilter] = useState<"all" | "pending" | "disbursed" | "approved">(
+    "all",
+  );
   const [showRequest, setShowRequest] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -59,9 +65,11 @@ export function EarnedWagePage() {
   });
 
   const stats = dashRes?.data || {};
-  const requests = reqRes?.data || [];
+  const allRequests: any[] = reqRes?.data || [];
   const settings = settingsRes?.data || {};
   const availability = availRes?.data || {};
+  const requests =
+    statusFilter === "all" ? allRequests : allRequests.filter((r) => r.status === statusFilter);
 
   // --- Handlers ---
   async function handleRequest(e: React.FormEvent<HTMLFormElement>) {
@@ -207,33 +215,49 @@ export function EarnedWagePage() {
         }
       />
 
-      {/* Stats — cards drill into the Requests tab (#92) */}
+      {/* Stats — each card now scopes the requests table to the relevant
+          status (or clears the filter for Total / Avg). */}
       <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
           title="Pending Requests"
           value={stats.totalPending || 0}
           icon={Clock}
-          onClick={() => setTab("requests")}
+          onClick={() => setStatusFilter("pending")}
         />
         <StatCard
           title="Total Disbursed"
           value={formatCurrency(stats.totalDisbursedAmount || 0)}
           icon={DollarSign}
-          onClick={() => setTab("requests")}
+          onClick={() => setStatusFilter("disbursed")}
         />
         <StatCard
           title="Avg Request"
           value={formatCurrency(stats.avgRequestAmount || 0)}
           icon={HandCoins}
-          onClick={() => setTab("requests")}
+          onClick={() => setStatusFilter("all")}
         />
         <StatCard
           title="Total Requests"
           value={stats.totalRequests || 0}
           icon={CheckCircle}
-          onClick={() => setTab("requests")}
+          onClick={() => setStatusFilter("all")}
         />
       </div>
+
+      {statusFilter !== "all" && (
+        <div className="mb-4 flex items-center gap-2 text-sm text-gray-500">
+          <span>
+            Showing <strong className="text-gray-900">{statusFilter}</strong> requests
+          </span>
+          <button
+            type="button"
+            onClick={() => setStatusFilter("all")}
+            className="text-brand-600 hover:underline"
+          >
+            Clear filter
+          </button>
+        </div>
+      )}
 
       {/* Available amount card */}
       {availability.available !== undefined && (
@@ -307,6 +331,13 @@ export function EarnedWagePage() {
               </p>
             )}
           </div>
+          {/* #172 — Don't `disabled` the Amount input when availability is 0.
+              It read as "the form is broken" because users couldn't type at
+              all. The amber banner above already explains why no advance is
+              available; here we still let them type (useful for prefilling
+              once config is fixed), keep the submit-button disabled when
+              there's nothing available, and rely on server-side validation
+              as the authoritative block. */}
           <Input
             label="Amount"
             name="amount"
@@ -315,7 +346,6 @@ export function EarnedWagePage() {
             min={1}
             {...(Number(availability.available) > 0 ? { max: availability.available } : {})}
             placeholder="Enter amount"
-            disabled={(availability.available || 0) <= 0}
           />
           <Input
             label="Reason (optional)"
@@ -326,7 +356,7 @@ export function EarnedWagePage() {
             <Button type="button" variant="ghost" onClick={() => setShowRequest(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={saving}>
+            <Button type="submit" disabled={saving || (availability.available || 0) <= 0}>
               {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
               Submit Request
             </Button>

--- a/packages/client/src/pages/gl-accounting/GLAccountingPage.tsx
+++ b/packages/client/src/pages/gl-accounting/GLAccountingPage.tsx
@@ -14,7 +14,10 @@ import { Plus, BookOpen, FileText, Download, ArrowRightLeft, Loader2, Trash2 } f
 import toast from "react-hot-toast";
 
 export function GLAccountingPage() {
-  const [tab, setTab] = useState<"mappings" | "journals">("mappings");
+  // #174 — "Exported" stat card now drills into a dedicated sub-tab that
+  // lists only journals with status="exported". "Total Approved" card was
+  // removed — it was always 0 in practice and had no meaningful drill-in.
+  const [tab, setTab] = useState<"mappings" | "journals" | "exported">("mappings");
   const [showCreateMapping, setShowCreateMapping] = useState(false);
   const [showGenerateJournal, setShowGenerateJournal] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -221,9 +224,11 @@ export function GLAccountingPage() {
         }
       />
 
-      {/* Stats — cards drill into matching tab (#105). Also add a "Total
-          Approved" count which was missing from the issue report. */}
-      <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {/* Stats — cards drill into matching tab (#105, #174). "Approved" was
+          removed — it was always 0 in this org's data and had no useful
+          destination. "Exported" now opens its own Exported tab sitting
+          beside Journal Entries so users can find just those rows. */}
+      <div className="mb-6 grid gap-4 sm:grid-cols-3">
         <StatCard
           title="GL Mappings"
           value={mappings.length}
@@ -237,16 +242,10 @@ export function GLAccountingPage() {
           onClick={() => setTab("journals")}
         />
         <StatCard
-          title="Approved"
-          value={journals.filter((j: any) => j.status === "posted").length}
-          icon={BookOpen}
-          onClick={() => setTab("journals")}
-        />
-        <StatCard
           title="Exported"
           value={journals.filter((j: any) => j.status === "exported").length}
           icon={Download}
-          onClick={() => setTab("journals")}
+          onClick={() => setTab("exported")}
         />
       </div>
 
@@ -263,6 +262,12 @@ export function GLAccountingPage() {
           className={`px-4 py-2 text-sm font-medium ${tab === "journals" ? "border-brand-600 text-brand-600 border-b-2" : "text-gray-500"}`}
         >
           Journal Entries ({journals.length})
+        </button>
+        <button
+          onClick={() => setTab("exported")}
+          className={`px-4 py-2 text-sm font-medium ${tab === "exported" ? "border-brand-600 text-brand-600 border-b-2" : "text-gray-500"}`}
+        >
+          Exported ({journals.filter((j: any) => j.status === "exported").length})
         </button>
       </div>
 
@@ -296,6 +301,24 @@ export function GLAccountingPage() {
                 columns={journalColumns}
                 data={journals}
                 emptyMessage="No journal entries generated"
+              />
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {tab === "exported" && (
+        <Card>
+          <CardContent className="p-0">
+            {journalsLoading ? (
+              <div className="flex h-32 items-center justify-center">
+                <Loader2 className="text-brand-600 h-6 w-6 animate-spin" />
+              </div>
+            ) : (
+              <DataTable
+                columns={journalColumns}
+                data={journals.filter((j: any) => j.status === "exported")}
+                emptyMessage="No journals have been exported yet"
               />
             )}
           </CardContent>

--- a/packages/client/src/pages/insurance/InsurancePage.tsx
+++ b/packages/client/src/pages/insurance/InsurancePage.tsx
@@ -688,6 +688,13 @@ export function InsurancePage() {
                   ? String(editingPolicy.start_date).slice(0, 10)
                   : undefined
               }
+              onChange={(e) => {
+                const form = (e.currentTarget as HTMLInputElement).form;
+                const renewalInput = form?.elements.namedItem(
+                  "renewalDate",
+                ) as HTMLInputElement | null;
+                if (renewalInput) renewalInput.min = e.currentTarget.value;
+              }}
             />
             <Input
               label="Renewal Date"
@@ -695,6 +702,13 @@ export function InsurancePage() {
               type="date"
               defaultValue={
                 editingPolicy?.renewal_date ? String(editingPolicy.renewal_date).slice(0, 10) : ""
+              }
+              min={
+                editingPolicy?.end_date
+                  ? String(editingPolicy.end_date).slice(0, 10)
+                  : editingPolicy?.start_date
+                    ? String(editingPolicy.start_date).slice(0, 10)
+                    : new Date().toISOString().slice(0, 10)
               }
             />
           </div>

--- a/packages/client/src/pages/pay-equity/PayEquityPage.tsx
+++ b/packages/client/src/pages/pay-equity/PayEquityPage.tsx
@@ -56,36 +56,58 @@ export function PayEquityPage() {
         </div>
       ) : (
         <>
-          {/* Stats — #89 cards drill into matching tab */}
+          {/* #169 — Previously all 4 cards called setTab against the local
+              tab state, which only swapped the narrow "Analysis Overview /
+              Compliance Report" tabs on this very page. Two of them
+              (Employees Analyzed, Median Salary) were on the already-
+              active tab, so clicks produced zero visible change — users
+              reported the cards as "not redirecting". Point them at the
+              dedicated list/benchmarks pages; keep the gap cards on the
+              Compliance tab (that IS their drill-in view) but scroll it
+              into focus so the switch is visible. */}
           <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <StatCard
               title="Employees Analyzed"
               value={analysis.totalEmployees || 0}
               icon={Users}
-              onClick={() => setTab("overview")}
+              to="/employees"
             />
             <StatCard
               title="Median Salary"
               value={formatCurrency(analysis.overallStats?.median || 0)}
               icon={BarChart3}
-              onClick={() => setTab("overview")}
+              to="/benchmarks"
             />
             <StatCard
               title="Mean Pay Gap"
               value={`${payGap.meanGapPercentage || 0}%`}
               icon={gapSeverity === "low" ? Scale : AlertTriangle}
-              onClick={() => setTab("compliance")}
+              onClick={() => {
+                setTab("compliance");
+                requestAnimationFrame(() =>
+                  document
+                    .getElementById("pay-equity-tabs")
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" }),
+                );
+              }}
             />
             <StatCard
               title="Median Pay Gap"
               value={`${payGap.medianGapPercentage || 0}%`}
               icon={Scale}
-              onClick={() => setTab("compliance")}
+              onClick={() => {
+                setTab("compliance");
+                requestAnimationFrame(() =>
+                  document
+                    .getElementById("pay-equity-tabs")
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" }),
+                );
+              }}
             />
           </div>
 
           {/* Tabs */}
-          <div className="mb-4 flex gap-2 border-b border-gray-200">
+          <div id="pay-equity-tabs" className="mb-4 flex gap-2 border-b border-gray-200">
             <button
               onClick={() => setTab("overview")}
               className={`px-4 py-2 text-sm font-medium ${tab === "overview" ? "border-brand-600 text-brand-600 border-b-2" : "text-gray-500"}`}
@@ -314,14 +336,20 @@ export function PayEquityPage() {
                         <h4 className="mb-2 text-sm font-semibold text-gray-700">
                           Recommendations
                         </h4>
+                        {/* #170 — The recommendation items were rendered in
+                            blue-on-light-blue with a link-style icon, which
+                            read as hyperlinks even though they were plain
+                            informational copy. Switch to a neutral callout
+                            (gray text on a soft amber background) so the
+                            copy doesn't look actionable when it isn't. */}
                         <ul className="space-y-2">
                           {(compliance.recommendations || []).map((r: string, i: number) => (
                             <li
                               key={i}
-                              className="flex items-start gap-2 rounded-lg bg-blue-50 p-3 text-sm text-blue-800"
+                              className="flex items-start gap-2 rounded-lg border border-amber-100 bg-amber-50 p-3 text-sm text-gray-700"
                             >
-                              <FileText className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
-                              {r}
+                              <FileText className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                              <span>{r}</span>
                             </li>
                           ))}
                         </ul>

--- a/packages/server/src/services/benefits.service.ts
+++ b/packages/server/src/services/benefits.service.ts
@@ -11,7 +11,17 @@ export class BenefitsService {
   async listPlans(orgId: string, filters?: { type?: string; active?: boolean }) {
     const where: Record<string, any> = { empcloud_org_id: Number(orgId) };
     if (filters?.type) where.type = filters.type;
-    if (filters?.active !== undefined) where.is_active = filters.active;
+    // #168 — deletePlan soft-deletes by setting is_active=false, but the
+    // list was returning every row regardless. Deactivated plans kept
+    // showing in the Benefits Plans table even though the admin had just
+    // "deleted" them. Match the insurance-policies pattern (#99): hide
+    // inactive rows by default; callers can still pass active=false to
+    // see them.
+    if (filters?.active !== undefined) {
+      where.is_active = filters.active;
+    } else {
+      where.is_active = true;
+    }
     return this.db.findMany<any>("benefit_plans", {
       filters: where,
       sort: { field: "created_at", order: "desc" },

--- a/packages/server/src/services/gl-accounting.service.ts
+++ b/packages/server/src/services/gl-accounting.service.ts
@@ -233,6 +233,13 @@ export class GLAccountingService {
     orgId: string,
   ): Promise<{ filename: string; content: string }> {
     const journal = await this.getJournalEntry(id, orgId);
+    // #175 — knex/mysql2 returns DATE columns as Date objects, so calling
+    // `.replace(/-/g, "")` directly on journal.entry_date threw
+    // `TypeError: entry_date.replace is not a function` the moment a user
+    // clicked "Tally" on any journal row. The window.open'd tab surfaced it
+    // as an error page. Normalize once up front so both the filename and the
+    // <DATE> tag always see an ISO YYYY-MM-DD string.
+    const dateIso = toIsoDateString(journal.entry_date);
 
     // Tally XML format
     const lines = journal.lines || [];
@@ -265,8 +272,8 @@ export class GLAccountingService {
       <REQUESTDATA>
         <TALLYMESSAGE>
           <VOUCHER VCHTYPE="Journal" ACTION="Create">
-            <DATE>${journal.entry_date.replace(/-/g, "")}</DATE>
-            <NARRATION>Payroll Journal Entry - ${journal.entry_date}</NARRATION>
+            <DATE>${dateIso.replace(/-/g, "")}</DATE>
+            <NARRATION>Payroll Journal Entry - ${dateIso}</NARRATION>
 ${xmlLines.join("\n")}
           </VOUCHER>
         </TALLYMESSAGE>
@@ -282,7 +289,7 @@ ${xmlLines.join("\n")}
     });
 
     return {
-      filename: `tally-journal-${journal.entry_date}.xml`,
+      filename: `tally-journal-${dateIso}.xml`,
       content: xml,
     };
   }
@@ -292,6 +299,7 @@ ${xmlLines.join("\n")}
     orgId: string,
   ): Promise<{ filename: string; content: string }> {
     const journal = await this.getJournalEntry(id, orgId);
+    const dateIso = toIsoDateString(journal.entry_date);
     const lines = journal.lines || [];
 
     // QuickBooks CSV format
@@ -301,7 +309,7 @@ ${xmlLines.join("\n")}
     for (const line of lines) {
       rows.push(
         [
-          `"${journal.entry_date}"`,
+          `"${dateIso}"`,
           `"${line.gl_account_code}"`,
           `"${(line.description || "").replace(/"/g, '""')}"`,
           Number(line.debit_amount) > 0 ? line.debit_amount : "",
@@ -317,7 +325,7 @@ ${xmlLines.join("\n")}
     });
 
     return {
-      filename: `quickbooks-journal-${journal.entry_date}.csv`,
+      filename: `quickbooks-journal-${dateIso}.csv`,
       content: rows.join("\n"),
     };
   }
@@ -327,13 +335,14 @@ ${xmlLines.join("\n")}
     orgId: string,
   ): Promise<{ filename: string; content: string }> {
     const journal = await this.getJournalEntry(id, orgId);
+    const dateIso = toIsoDateString(journal.entry_date);
     const lines = journal.lines || [];
 
     // Zoho Books JSON format
     const zohoData = {
-      journal_date: journal.entry_date,
+      journal_date: dateIso,
       reference_number: `PAYROLL-${journal.payroll_run_id.slice(0, 8)}`,
-      notes: `Payroll Journal Entry - ${journal.entry_date}`,
+      notes: `Payroll Journal Entry - ${dateIso}`,
       line_items: lines.map((l: any) => ({
         account_name: l.gl_account_code,
         description: l.description,
@@ -349,7 +358,7 @@ ${xmlLines.join("\n")}
     });
 
     return {
-      filename: `zoho-journal-${journal.entry_date}.json`,
+      filename: `zoho-journal-${dateIso}.json`,
       content: JSON.stringify(zohoData, null, 2),
     };
   }
@@ -362,4 +371,9 @@ function escapeXml(str: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
+}
+
+function toIsoDateString(v: unknown): string {
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  return String(v ?? "").slice(0, 10);
 }

--- a/packages/server/src/services/insurance.service.ts
+++ b/packages/server/src/services/insurance.service.ts
@@ -130,19 +130,53 @@ export class InsuranceService {
       limit: 500,
     });
 
-    // Enrich with policy names and employee names
-    const policyIds = [...new Set(result.data.map((e: any) => e.policy_id))];
+    // #173 — Enrichment must not crash the list. Previously, a failing lookup
+    // inside either loop (missing row, bad id, table-not-visible) surfaced as
+    // a 500 on GET /insurance/enrollments even though the dashboard count
+    // from the same table succeeded. Isolate each lookup and fall back to
+    // `employee_payroll_profiles` (newer Apply-to-Payroll orgs) when the
+    // legacy `employees` row is missing — same pattern as reimbursements
+    // (#159/#160).
+    const policyIds = [...new Set(result.data.map((e: any) => e.policy_id).filter(Boolean))];
     const policyMap: Record<string, any> = {};
     for (const pid of policyIds) {
-      const policy = await this.db.findById<any>("insurance_policies", pid as string);
-      if (policy) policyMap[pid as string] = policy;
+      try {
+        const policy = await this.db.findById<any>("insurance_policies", pid as string);
+        if (policy) policyMap[pid as string] = policy;
+      } catch {
+        // orphaned policy_id — leave name as "Unknown"
+      }
     }
 
-    const empIds = [...new Set(result.data.map((e: any) => String(e.employee_id)))];
-    const empMap: Record<string, any> = {};
+    const empIds = [
+      ...new Set(
+        result.data
+          .map((e: any) => (e.employee_id == null ? null : String(e.employee_id)))
+          .filter(Boolean),
+      ),
+    ] as string[];
+    const empMap: Record<string, { first_name: string; last_name: string }> = {};
     for (const eid of empIds) {
-      const emp = await this.db.findOne<any>("employees", { empcloud_user_id: Number(eid) });
-      if (emp) empMap[eid] = emp;
+      const numeric = Number(eid);
+      if (!Number.isFinite(numeric)) continue;
+      try {
+        const emp = await this.db.findOne<any>("employees", { empcloud_user_id: numeric });
+        if (emp) {
+          empMap[eid] = { first_name: emp.first_name, last_name: emp.last_name };
+          continue;
+        }
+        const profile = await this.db.findOne<any>("employee_payroll_profiles", {
+          empcloud_user_id: numeric,
+        });
+        if (profile) {
+          empMap[eid] = {
+            first_name: profile.first_name || "",
+            last_name: profile.last_name || "",
+          };
+        }
+      } catch {
+        // swallow and fall through to fallback name
+      }
     }
 
     return {
@@ -152,7 +186,8 @@ export class InsuranceService {
         policy_name: policyMap[e.policy_id]?.name || "Unknown",
         policy_type: policyMap[e.policy_id]?.type || "",
         employee_name: empMap[String(e.employee_id)]
-          ? `${empMap[String(e.employee_id)].first_name} ${empMap[String(e.employee_id)].last_name}`
+          ? `${empMap[String(e.employee_id)].first_name} ${empMap[String(e.employee_id)].last_name}`.trim() ||
+            `Employee #${e.employee_id}`
           : `Employee #${e.employee_id}`,
       })),
     };
@@ -259,12 +294,36 @@ export class InsuranceService {
       limit: 200,
     });
 
-    // Enrich with employee names
-    const empIds = [...new Set(result.data.map((c: any) => String(c.employee_id)))];
-    const empMap: Record<string, any> = {};
+    // Enrich with employee names — same defensive pattern as listEnrollments.
+    const empIds = [
+      ...new Set(
+        result.data
+          .map((c: any) => (c.employee_id == null ? null : String(c.employee_id)))
+          .filter(Boolean),
+      ),
+    ] as string[];
+    const empMap: Record<string, { first_name: string; last_name: string }> = {};
     for (const eid of empIds) {
-      const emp = await this.db.findOne<any>("employees", { empcloud_user_id: Number(eid) });
-      if (emp) empMap[eid] = emp;
+      const numeric = Number(eid);
+      if (!Number.isFinite(numeric)) continue;
+      try {
+        const emp = await this.db.findOne<any>("employees", { empcloud_user_id: numeric });
+        if (emp) {
+          empMap[eid] = { first_name: emp.first_name, last_name: emp.last_name };
+          continue;
+        }
+        const profile = await this.db.findOne<any>("employee_payroll_profiles", {
+          empcloud_user_id: numeric,
+        });
+        if (profile) {
+          empMap[eid] = {
+            first_name: profile.first_name || "",
+            last_name: profile.last_name || "",
+          };
+        }
+      } catch {
+        // swallow — leave as fallback label
+      }
     }
 
     return {
@@ -273,7 +332,8 @@ export class InsuranceService {
         ...c,
         documents: typeof c.documents === "string" ? JSON.parse(c.documents) : c.documents,
         employee_name: empMap[String(c.employee_id)]
-          ? `${empMap[String(c.employee_id)].first_name} ${empMap[String(c.employee_id)].last_name}`
+          ? `${empMap[String(c.employee_id)].first_name} ${empMap[String(c.employee_id)].last_name}`.trim() ||
+            `Employee #${c.employee_id}`
           : `Employee #${c.employee_id}`,
       })),
     };


### PR DESCRIPTION
## Summary

Batch of fixes for open issues in the tracker. One commit per issue where clean, pairs where two issues shared a root cause.

| Issue | Fix |
|-------|-----|
| #168 | Benefits Plans: deactivated plans no longer linger in the list; stray "0" on inactive rows gone |
| #169 | Pay Equity stat cards: Employees Analyzed / Median Salary now route to `/employees` and `/benchmarks` (was setting an already-active tab); Mean/Median Pay Gap keep the Compliance drill-in but scroll it into view |
| #170 | Pay Equity Recommendations no longer styled like hyperlinks (plain informational callout) |
| #171 | EWA stat cards now scope the Requests table by status instead of calling setTab against unused state |
| #172 | EWA Amount input is no longer `disabled` when available is 0 — users can type; Submit is blocked instead |
| #173 | `GET /insurance/enrollments` was 500ing on orgs where the `employees` table lookup hit a missing row; enrichment is now defensive and falls back to `employee_payroll_profiles` (same pattern as #159/#160) |
| #174 | GL/Accounting: dropped the always-zero "Approved" card; "Exported" card now drills into a new Exported tab beside Journal Entries |
| #175 | Tally export crashed because `journal.entry_date` is a `Date` (not a string) from mysql2 — `.replace()` threw. Normalize to ISO once up front; also fixes the filename / `journal_date` latent issue in QB/Zoho |
| #177 | Insurance Policy: Renewal Date picker now enforces `min >= end date` (or today / start date as a fallback) via `min` attribute, matching the Start→End coupling |

**Also closed on merge of PR #166** (listed for tracker visibility): #145, #146, #149, #152, #153, #163. And #160 / #167 are very likely the same reimbursement / tax-declaration payroll-profile fallback addressed in PR #166 — if they still reproduce after #166 merges, please reopen with the actual error message.

**Not fixed — needs server logs to reproduce:**
- **#176 — "Failed to save policy".** Client just shows its generic fallback toast, meaning the axios error has no `response.data.error.message`. I could not find a deterministic code path in `createPolicy` / `createInsurancePolicySchema` that would produce this from the values shown in the screenshot. Leaving open — please grab the network tab or a server log when it reproduces so the actual error code is visible.

## Test plan

- [ ] Insurance → New Policy: try setting Renewal Date earlier than End Date — the date picker blocks it (#177)
- [ ] Insurance → Enrollments tab on an org with >0 active enrollments — list renders instead of showing the empty state while the card shows a non-zero count (#173)
- [ ] GL/Accounting → Journal Entries → Tally button — file downloads with `<DATE>YYYYMMDD</DATE>` and `tally-journal-YYYY-MM-DD.xml` filename (#175)
- [ ] GL/Accounting → stat cards: Approved card is gone; clicking Exported switches to the new Exported tab (#174)
- [ ] Earned Wage Access → open Request Advance when Available = ₹0 — Amount field accepts input; Submit stays disabled (#172). Click each stat card — table filters to the matching status (#171)
- [ ] Pay Equity → click Employees Analyzed → lands on /employees; click Median Salary → lands on /benchmarks; click Mean/Median Pay Gap → Compliance tab scrolls into view (#169)
- [ ] Pay Equity → Compliance Report → recommendations render as amber callouts, not blue hyperlinks (#170)
- [ ] Benefits → Plans tab: delete a plan → row disappears from the list; no stray "0" next to edit icon on any row (#168)