### PR TITLE
fix: pay equity card destinations + visual differentiation

### DIFF
--- a/packages/client/src/components/ui/StatCard.tsx
+++ b/packages/client/src/components/ui/StatCard.tsx
@@ -9,6 +9,12 @@ interface StatCardProps {
   icon: LucideIcon;
   trend?: { value: string; positive: boolean };
   className?: string;
+  /**
+   * Override the icon-bubble accent — Tailwind classes for the bg/text
+   * combo (e.g. "bg-emerald-50 text-emerald-600"). Defaults to brand.
+   * Use this to differentiate cards that would otherwise look identical.
+   */
+  accentClassName?: string;
   /** When set, the whole card becomes a react-router Link to this path. */
   to?: string;
   /** When set (and `to` is not), the card is a button with this handler. */
@@ -22,6 +28,7 @@ export function StatCard({
   icon: Icon,
   trend,
   className,
+  accentClassName,
   to,
   onClick,
 }: StatCardProps) {
@@ -57,8 +64,10 @@ export function StatCard({
           </p>
         )}
       </div>
-      <div className="bg-brand-50 shrink-0 rounded-lg p-3">
-        <Icon className="text-brand-600 h-6 w-6" />
+      <div
+        className={cn("shrink-0 rounded-lg p-3", accentClassName ?? "bg-brand-50 text-brand-600")}
+      >
+        <Icon className="h-6 w-6" />
       </div>
     </div>
   );

--- a/packages/client/src/pages/pay-equity/PayEquityPage.tsx
+++ b/packages/client/src/pages/pay-equity/PayEquityPage.tsx
@@ -56,32 +56,55 @@ export function PayEquityPage() {
         </div>
       ) : (
         <>
-          {/* #169 — Previously all 4 cards called setTab against the local
-              tab state, which only swapped the narrow "Analysis Overview /
-              Compliance Report" tabs on this very page. Two of them
-              (Employees Analyzed, Median Salary) were on the already-
-              active tab, so clicks produced zero visible change — users
-              reported the cards as "not redirecting". Point them at the
-              dedicated list/benchmarks pages; keep the gap cards on the
-              Compliance tab (that IS their drill-in view) but scroll it
-              into focus so the switch is visible. */}
+          {/* Card click behaviours:
+              - Employees Analyzed: scroll to the per-department / per-role
+                breakdown on this page so the user actually sees the
+                employees-analyzed breakdown instead of the org-wide
+                /employees roster (#204).
+              - Median Salary: scroll to the Role / Designation analysis
+                section that has p25/p50/p75 — the dedicated /benchmarks
+                page is empty until org-wide market data is wired up (#205).
+              - Mean / Median Pay Gap: same compliance drill-in target,
+                but rendered with distinct icon + color so they don't look
+                like the same card duplicated (#203). */}
           <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <StatCard
               title="Employees Analyzed"
               value={analysis.totalEmployees || 0}
               icon={Users}
-              to="/employees"
+              onClick={() => {
+                setTab("overview");
+                requestAnimationFrame(() =>
+                  document
+                    .getElementById("pe-employees-analyzed")
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" }),
+                );
+              }}
             />
             <StatCard
               title="Median Salary"
               value={formatCurrency(analysis.overallStats?.median || 0)}
               icon={BarChart3}
-              to="/benchmarks"
+              onClick={() => {
+                setTab("overview");
+                requestAnimationFrame(() =>
+                  document
+                    .getElementById("pe-role-analysis")
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" }),
+                );
+              }}
             />
             <StatCard
               title="Mean Pay Gap"
               value={`${payGap.meanGapPercentage || 0}%`}
               icon={gapSeverity === "low" ? Scale : AlertTriangle}
+              accentClassName={
+                gapSeverity === "high"
+                  ? "bg-red-50 text-red-600"
+                  : gapSeverity === "medium"
+                    ? "bg-amber-50 text-amber-600"
+                    : "bg-emerald-50 text-emerald-600"
+              }
               onClick={() => {
                 setTab("compliance");
                 requestAnimationFrame(() =>
@@ -94,7 +117,8 @@ export function PayEquityPage() {
             <StatCard
               title="Median Pay Gap"
               value={`${payGap.medianGapPercentage || 0}%`}
-              icon={Scale}
+              icon={TrendingDown}
+              accentClassName="bg-indigo-50 text-indigo-600"
               onClick={() => {
                 setTab("compliance");
                 requestAnimationFrame(() =>
@@ -202,7 +226,7 @@ export function PayEquityPage() {
               {/* Department Analysis */}
               {analysis.departmentAnalysis && (
                 <Card>
-                  <CardContent className="p-6">
+                  <CardContent className="p-6" id="pe-employees-analyzed">
                     <h3 className="mb-4 text-lg font-semibold text-gray-900">
                       Department Analysis
                     </h3>
@@ -255,7 +279,7 @@ export function PayEquityPage() {
               {/* Role Analysis */}
               {analysis.roleAnalysis && (
                 <Card>
-                  <CardContent className="p-6">
+                  <CardContent className="p-6" id="pe-role-analysis">
                     <h3 className="mb-4 text-lg font-semibold text-gray-900">
                       Role / Designation Analysis
                     </h3>


### PR DESCRIPTION
## Summary
- Employees Analyzed and Median Salary cards previously linked to /employees and /benchmarks. /employees is the org-wide roster, not an employees-analyzed view, and /benchmarks renders empty until market data is populated. Re-target both to anchored sections on this page (Department Analysis = #pe-employees-analyzed, Role Analysis = #pe-role-analysis) so the click surfaces the drill-in data the user expects (#204, #205).
- Mean Pay Gap and Median Pay Gap cards looked like the same card twice — same palette, same Scale icon, same target. Add accentClassName to StatCard and color the Mean card by severity (red / amber / emerald), Median in indigo with TrendingDown icon, so they read as two distinct metrics (#203).

Closes #203
Closes #204
Closes #205

## Test plan
- [ ] Click Employees Analyzed -> page scrolls to Department Analysis table.
- [ ] Click Median Salary -> scrolls to Role / Designation Analysis.
- [ ] Mean Pay Gap and Median Pay Gap cards are visually distinct.