### PR TITLE
fix: global dashboard card destinations honour their filters

### DIFF
--- a/packages/client/src/pages/global-payroll/ContractorInvoicesPage.tsx
+++ b/packages/client/src/pages/global-payroll/ContractorInvoicesPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Card, CardContent } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
@@ -23,7 +24,10 @@ export function ContractorInvoicesPage() {
   const qc = useQueryClient();
   const [showSubmit, setShowSubmit] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [statusFilter, setStatusFilter] = useState("");
+  // Seed filter from URL so the dashboard's "Pending Invoices" card actually
+  // lands the user on a pending-only view instead of all statuses (#236).
+  const [searchParams] = useSearchParams();
+  const [statusFilter, setStatusFilter] = useState(searchParams.get("status") || "");
 
   const [form, setForm] = useState({
     globalEmployeeId: "",

--- a/packages/client/src/pages/global-payroll/CountryCompliancePage.tsx
+++ b/packages/client/src/pages/global-payroll/CountryCompliancePage.tsx
@@ -64,10 +64,26 @@ export function CountryCompliancePage() {
   const [search, setSearch] = useState("");
   const [regionFilter, setRegionFilter] = useState("");
   const [selectedCountryId, setSelectedCountryId] = useState<string | null>(null);
+  // When the user lands here from the Global Dashboard "Countries" card
+  // (?configured=true), narrow the list to countries the org actually has
+  // employees in. Defaults to false so the page still doubles as a global
+  // catalogue when accessed directly (#235).
+  const [configuredOnly, setConfiguredOnly] = useState(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get("configured") === "true";
+  });
 
   const { data: countriesRes, isLoading } = useQuery({
     queryKey: ["global-countries", regionFilter],
     queryFn: () => apiGet<any>("/global/countries", { region: regionFilter || undefined }),
+  });
+
+  // Pull the dashboard payload to know which countries the org has set up.
+  // Already cached if the user came from the dashboard.
+  const { data: dashRes } = useQuery({
+    queryKey: ["global-dashboard"],
+    queryFn: () => apiGet<any>("/global/dashboard"),
+    enabled: configuredOnly,
   });
 
   const { data: countryDetail } = useQuery({
@@ -76,7 +92,16 @@ export function CountryCompliancePage() {
     enabled: !!selectedCountryId,
   });
 
+  const configuredCountryCodes = new Set<string>(
+    (dashRes?.data?.employeesByCountry || [])
+      .map((c: any) => (c.country_code || c.code || "").toUpperCase())
+      .filter(Boolean),
+  );
+
   const countries = (countriesRes?.data || []).filter((c: any) => {
+    if (configuredOnly && configuredCountryCodes.size > 0) {
+      if (!configuredCountryCodes.has((c.code || "").toUpperCase())) return false;
+    }
     if (!search) return true;
     const q = search.toLowerCase();
     return c.name.toLowerCase().includes(q) || c.code.toLowerCase().includes(q);
@@ -110,6 +135,17 @@ export function CountryCompliancePage() {
                 value={regionFilter}
                 onChange={(e) => setRegionFilter(e.target.value)}
               />
+              {configuredCountryCodes.size > 0 && (
+                <label className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+                  <input
+                    type="checkbox"
+                    checked={configuredOnly}
+                    onChange={(e) => setConfiguredOnly(e.target.checked)}
+                    className="h-4 w-4 rounded border-gray-300"
+                  />
+                  Only my configured countries ({configuredCountryCodes.size})
+                </label>
+              )}
             </CardContent>
           </Card>
 

--- a/packages/client/src/pages/global-payroll/GlobalDashboardPage.tsx
+++ b/packages/client/src/pages/global-payroll/GlobalDashboardPage.tsx
@@ -80,10 +80,16 @@ export function GlobalDashboardPage() {
 
       {/* Stats — each card links to the drill-down page (#115) */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Link to="/global-payroll/employees" className="block transition hover:-translate-y-0.5">
+        <Link
+          to="/global-payroll/employees?status=active"
+          className="block transition hover:-translate-y-0.5"
+        >
           <StatCard title="Active Employees" value={String(dash?.totalActive || 0)} icon={Users} />
         </Link>
-        <Link to="/global-payroll/compliance" className="block transition hover:-translate-y-0.5">
+        <Link
+          to="/global-payroll/compliance?configured=true"
+          className="block transition hover:-translate-y-0.5"
+        >
           <StatCard title="Countries" value={String(dash?.totalCountries || 0)} icon={Globe} />
         </Link>
         <Link


### PR DESCRIPTION
## Summary
- Active Employees card now links to /global-payroll/employees?status=active so the destination is filtered to active rather than the org-wide roster (#234).
- Countries card links to /global-payroll/compliance?configured=true. CountryCompliancePage seeds a configured-only filter from that param, narrows the list to countries the org actually has employees in (from /global/dashboard.employeesByCountry), and exposes a checkbox to flip back to the full catalogue (#235).
- ContractorInvoicesPage now seeds statusFilter from useSearchParams() so /global-payroll/invoices?status=pending lands on a pending-only view instead of all statuses (#236).

Closes #234
Closes #235
Closes #236

## Test plan
- [ ] Click Active Employees card -> employees page opens with status=active applied.
- [ ] Click Countries card with 2 configured countries -> compliance page lists only those 2; toggle off to see all.
- [ ] Click Pending Invoices card -> invoices page shows only pending rows.