### PR TITLE
fix: tax declaration submit no longer rejects 0 + proof now optional

### DIFF
--- a/packages/client/src/pages/self-service/MyDeclarationsPage.tsx
+++ b/packages/client/src/pages/self-service/MyDeclarationsPage.tsx
@@ -162,9 +162,10 @@ export function MyDeclarationsPage() {
         else if (field === "declaredAmount") errors.amount = issue.message;
       }
     }
-    if (!proofFile) {
-      errors.proof = "Please upload a proof document";
-    }
+    // Proof upload is not yet wired up server-side (the route just returns
+    // a placeholder), so don't block submission on missing proof — that
+    // was preventing employees from submitting declarations at all (#201).
+    // We still validate the file's type/size at selection time.
 
     if (Object.keys(errors).length > 0) {
       setFieldErrors(errors);
@@ -438,7 +439,9 @@ export function MyDeclarationsPage() {
             error={fieldErrors.amount}
           />
           <div>
-            <label className="block text-sm font-medium text-gray-700">Proof Document</label>
+            <label className="block text-sm font-medium text-gray-700">
+              Proof Document <span className="text-xs font-normal text-gray-400">(optional)</span>
+            </label>
             <div
               role="button"
               tabIndex={0}

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -279,14 +279,20 @@ export const createPayrollRunSchema = z.object({
 // ---------------------------------------------------------------------------
 export const submitDeclarationSchema = z.object({
   body: z.object({
-    financialYear: z.string(),
-    declarations: z.array(
-      z.object({
-        section: z.string(),
-        description: z.string(),
-        declaredAmount: z.number().positive(),
-      }),
-    ),
+    financialYear: z.string().min(1),
+    // Accept 0 (placeholder declarations) — the service treats < 0 as the
+    // hard error. Schema previously required positive(), which rejected
+    // any 0-amount the UI legitimately submits, returning a 400 the
+    // service would never have raised (#201, #212, #214).
+    declarations: z
+      .array(
+        z.object({
+          section: z.string().min(1),
+          description: z.string().min(1),
+          declaredAmount: z.number().nonnegative(),
+        }),
+      )
+      .min(1),
   }),
 });
 


### PR DESCRIPTION
## Summary
- submitDeclarationSchema required declaredAmount > 0, but the service accepts >= 0 and the wizard skips zeros anyway. Mismatch caused legitimate submissions to be rejected with a 400 instead of being saved (#201, #212, #214). Align the schema to nonnegative() and add min(1) on the array so a clear error fires for an empty submit.
- Drop the proof-required client guard. The /tax/declarations/:id/proof route is still a placeholder that returns a pending message without persisting the file. Forcing employees to upload a proof that never reaches storage was blocking submissions; mark the upload as Optional until storage lands.

Closes #201
Closes #212
Closes #214

## Test plan
- [ ] Open Declarations > New Declaration, fill section + description + amount, leave proof empty -> submit succeeds.
- [ ] Submit-all wizard with one filled section -> succeeds.