### PR TITLE
fix: employee detail title, department dropdown, doc view 404

### DIFF
--- a/packages/client/src/pages/employees/EmployeeDetailPage.tsx
+++ b/packages/client/src/pages/employees/EmployeeDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   useSalaryStructures,
 } from "@/api/hooks";
 import { apiGet, apiPost, apiDelete, apiPut } from "@/api/client";
+import { useDepartments } from "@/api/hooks";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
@@ -68,6 +69,11 @@ export function EmployeeDetailPage() {
   });
   const updateMutation = useUpdateEmployee(id!);
   const { data: structuresRes } = useSalaryStructures();
+  const { data: deptsData } = useDepartments();
+  const deptOptions = (deptsData?.data?.data || deptsData?.data || []).map((d: any) => ({
+    value: d.name,
+    label: d.name,
+  }));
   const [editOpen, setEditOpen] = useState(false);
   const [salaryOpen, setSalaryOpen] = useState(false);
   const [salaryAssigning, setSalaryAssigning] = useState(false);
@@ -126,7 +132,10 @@ export function EmployeeDetailPage() {
   return (
     <div className="space-y-6">
       <PageHeader
-        title=""
+        title={`${emp.first_name} ${emp.last_name}`.trim() || "Employee"}
+        description={
+          emp.designation && emp.department ? `${emp.designation} · ${emp.department}` : undefined
+        }
         actions={
           <Button variant="ghost" onClick={() => navigate("/employees")}>
             <ArrowLeft className="h-4 w-4" /> Back to Employees
@@ -458,13 +467,32 @@ export function EmployeeDetailPage() {
           </div>
           <Input id="phone" name="phone" label="Phone" defaultValue={emp.phone || ""} />
           <div className="grid grid-cols-2 gap-4">
-            <Input
-              id="department"
-              name="department"
-              label="Department"
-              defaultValue={emp.department}
-              required
-            />
+            {deptOptions.length > 0 ? (
+              <SelectField
+                id="department"
+                name="department"
+                label="Department"
+                defaultValue={emp.department || ""}
+                options={[
+                  { value: "", label: "— Select department —" },
+                  ...(deptOptions.find((d: any) => d.value === emp.department)
+                    ? deptOptions
+                    : [
+                        { value: emp.department, label: `${emp.department} (current)` },
+                        ...deptOptions,
+                      ]),
+                ]}
+                required
+              />
+            ) : (
+              <Input
+                id="department"
+                name="department"
+                label="Department"
+                defaultValue={emp.department}
+                required
+              />
+            )}
             <Input
               id="designation"
               name="designation"

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -29,6 +29,14 @@ export default defineConfig({
         target: "http://localhost:4000",
         changeOrigin: true,
       },
+      // #219 — Employee documents are served as `/uploads/<file>` by the
+      // backend's express.static handler. Without this proxy entry the
+      // request hits the Vite dev server (which has no such file) and
+      // the doc-view link 404s in dev.
+      "/uploads": {
+        target: "http://localhost:4000",
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- PageHeader title was hard-coded to empty so the detail page showed an empty header, leaving the URL numeric id as the only on-screen identifier. Set title to first+last name (#220).
- Edit Employee modal now drives Department off the orgs department list via useDepartments() instead of a freeform input. Falls back to the input when the list is empty so unconfigured orgs arent locked out (#218).
- Document view links (/uploads/<file>) 404d in dev because the Vite proxy only routed /api and /health to the backend. Add /uploads to the proxy so the static handler on the server serves the file (#219).

Closes #218
Closes #219
Closes #220

## Test plan
- [ ] Open /employees/:id -> page header shows employee name.
- [ ] Click Edit -> Department field is a dropdown sourced from /departments.
- [ ] Upload a document, click its name -> opens the file inline (no longer 404).