### PR TITLE
fix: reimbursement admin sync + clickable summary cards

### DIFF
--- a/packages/client/src/pages/self-service/MyReimbursementsPage.tsx
+++ b/packages/client/src/pages/self-service/MyReimbursementsPage.tsx
@@ -26,6 +26,7 @@ const CATEGORIES = [
 export function MyReimbursementsPage() {
   const [showAdd, setShowAdd] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<"all" | "pending" | "approved">("all");
   const qc = useQueryClient();
 
   // #1358 — Request a large page so client-side pagination has all records
@@ -43,6 +44,13 @@ export function MyReimbursementsPage() {
   const totalApproved = claims
     .filter((c: any) => c.status === "approved" || c.status === "paid")
     .reduce((s: number, c: any) => s + Number(c.amount), 0);
+
+  const visibleClaims =
+    statusFilter === "all"
+      ? claims
+      : statusFilter === "pending"
+        ? claims.filter((c: any) => c.status === "pending")
+        : claims.filter((c: any) => c.status === "approved" || c.status === "paid");
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -83,25 +91,51 @@ export function MyReimbursementsPage() {
         }
       />
 
+      {/* Stat cards double as filter buttons — clicking one narrows the
+          claims list below to that status (#237). */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <Card>
-          <CardContent className="py-4">
-            <p className="text-sm text-gray-500">Total Claims</p>
-            <p className="text-xl font-bold">{claims.length}</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="py-4">
-            <p className="text-sm text-gray-500">Pending</p>
-            <p className="text-xl font-bold text-orange-600">{formatCurrency(totalPending)}</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="py-4">
-            <p className="text-sm text-gray-500">Approved / Paid</p>
-            <p className="text-xl font-bold text-green-600">{formatCurrency(totalApproved)}</p>
-          </CardContent>
-        </Card>
+        <button
+          type="button"
+          onClick={() => setStatusFilter("all")}
+          className={`text-left transition ${
+            statusFilter === "all" ? "ring-brand-500 rounded-lg ring-2" : ""
+          }`}
+        >
+          <Card>
+            <CardContent className="py-4">
+              <p className="text-sm text-gray-500">Total Claims</p>
+              <p className="text-xl font-bold">{claims.length}</p>
+            </CardContent>
+          </Card>
+        </button>
+        <button
+          type="button"
+          onClick={() => setStatusFilter("pending")}
+          className={`text-left transition ${
+            statusFilter === "pending" ? "ring-brand-500 rounded-lg ring-2" : ""
+          }`}
+        >
+          <Card>
+            <CardContent className="py-4">
+              <p className="text-sm text-gray-500">Pending</p>
+              <p className="text-xl font-bold text-orange-600">{formatCurrency(totalPending)}</p>
+            </CardContent>
+          </Card>
+        </button>
+        <button
+          type="button"
+          onClick={() => setStatusFilter("approved")}
+          className={`text-left transition ${
+            statusFilter === "approved" ? "ring-brand-500 rounded-lg ring-2" : ""
+          }`}
+        >
+          <Card>
+            <CardContent className="py-4">
+              <p className="text-sm text-gray-500">Approved / Paid</p>
+              <p className="text-xl font-bold text-green-600">{formatCurrency(totalApproved)}</p>
+            </CardContent>
+          </Card>
+        </button>
       </div>
 
       {isLoading ? (
@@ -159,7 +193,7 @@ export function MyReimbursementsPage() {
               },
             },
           ]}
-          data={claims}
+          data={visibleClaims}
         />
       )}
 

--- a/packages/server/src/services/reimbursement.service.ts
+++ b/packages/server/src/services/reimbursement.service.ts
@@ -19,17 +19,36 @@ export class ReimbursementService {
   private db = getDB();
 
   async list(orgId: string, filters?: { status?: string; employeeId?: string }) {
-    // Get employees for this org, then filter reimbursements
+    // The legacy `employees` table is one source of truth; the newer flow
+    // writes to `employee_payroll_profiles`. submit() writes
+    // reimbursements.employee_id with whichever id matched, so the admin
+    // list has to consider both tables — otherwise claims submitted by
+    // anyone onboarded via the new flow are invisible here (#215, #216).
     const employees = await this.db.findMany<any>("employees", {
       filters: { org_id: orgId, is_active: true },
       limit: 10000,
     });
-    const empIds = employees.data.map((e: any) => e.id);
+    const profiles = await this.db
+      .findMany<any>("employee_payroll_profiles", {
+        filters: { org_id: orgId, is_active: 1 },
+        limit: 10000,
+      })
+      .catch(() => ({ data: [] as any[] }));
+
+    const empMap: Record<string, any> = {};
+    for (const emp of employees.data) empMap[emp.id] = emp;
+    for (const prof of profiles.data) {
+      // Don't clobber a legacy row with a profile of the same uuid.
+      if (!empMap[prof.id]) empMap[prof.id] = prof;
+    }
+
+    const empIds = Object.keys(empMap);
     if (empIds.length === 0) return { data: [], total: 0, page: 1, limit: 50, totalPages: 0 };
 
-    const queryFilters: any = { employee_id: empIds };
+    const queryFilters: any = filters?.employeeId
+      ? { employee_id: filters.employeeId }
+      : { employee_id: empIds };
     if (filters?.status) queryFilters.status = filters.status;
-    if (filters?.employeeId) queryFilters.employee_id = filters.employeeId;
 
     const result = await this.db.findMany<any>("reimbursements", {
       filters: queryFilters,
@@ -37,17 +56,14 @@ export class ReimbursementService {
       limit: 100,
     });
 
-    // Attach employee names
-    const empMap: Record<string, any> = {};
-    for (const emp of employees.data) empMap[emp.id] = emp;
-
-    const enriched = result.data.map((r: any) => ({
-      ...r,
-      employee_name: empMap[r.employee_id]
-        ? `${empMap[r.employee_id].first_name} ${empMap[r.employee_id].last_name}`
-        : "Unknown",
-      employee_code: empMap[r.employee_id]?.employee_code || "",
-    }));
+    const enriched = result.data.map((r: any) => {
+      const row = empMap[r.employee_id];
+      return {
+        ...r,
+        employee_name: row ? `${row.first_name} ${row.last_name}` : "Unknown",
+        employee_code: row?.employee_code || "",
+      };
+    });
 
     return { ...result, data: enriched };
   }


### PR DESCRIPTION
## Summary
- Admin reimbursement list filtered employee_id against the legacy employees table only. submit() resolves through either employees or employee_payroll_profiles, so claims from anyone onboarded via the new flow had an employee_id the admin query never matched, leaving them invisible to HR (#215, #216). Build empMap from both tables and filter the reimbursements query against the union.
- The three summary cards on My Reimbursements were decorative; wrap each in a button that swaps the table between all / pending / approved+paid, with a brand ring on the active card (#237).

Closes #215
Closes #216
Closes #237

## Test plan
- [ ] Submit a reimbursement from the employee portal -> appears in HR /reimbursements list immediately.
- [ ] On My Reimbursements, click Pending card -> table narrows to pending rows; click Total Claims -> all rows return.