### PR TITLE
fix: insurance policy number cannot start with minus + loan names

### DIFF
--- a/packages/client/src/pages/insurance/InsurancePage.tsx
+++ b/packages/client/src/pages/insurance/InsurancePage.tsx
@@ -144,10 +144,18 @@ export function InsurancePage() {
         return;
       }
     }
+    // #221 — Policy numbers are identifiers (e.g. "POL-2024-001"), never
+    // negative figures. Reject a leading "-" or a pure-negative value
+    // before sending so HR can't accidentally save a malformed id.
+    const policyNumber = String(fd.get("policyNumber") || "").trim();
+    if (policyNumber && (policyNumber.startsWith("-") || /^-\d/.test(policyNumber))) {
+      toast.error("Policy number cannot start with a minus sign");
+      return;
+    }
     setSaving(true);
     const payload = {
       name: fd.get("name"),
-      policyNumber: fd.get("policyNumber") || undefined,
+      policyNumber: policyNumber || undefined,
       provider: fd.get("provider"),
       type: fd.get("type"),
       premiumTotal: Number(fd.get("premiumTotal") || 0),
@@ -617,6 +625,9 @@ export function InsurancePage() {
               label="Policy Number"
               name="policyNumber"
               defaultValue={editingPolicy?.policy_number || ""}
+              pattern="[^\-].*"
+              title="Policy number cannot start with a minus sign"
+              placeholder="e.g. POL-2024-001"
             />
             <Input
               label="Provider"

--- a/packages/server/src/services/loan.service.ts
+++ b/packages/server/src/services/loan.service.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { getDB } from "../db/adapters";
+import { getEmpCloudDB } from "../db/empcloud";
 import { AppError } from "../api/middleware/error.middleware";
 
 // Zod schema for loan creation — lives in the service so we don't have to
@@ -38,23 +39,57 @@ export class LoanService {
       limit: 100,
     });
 
-    // Enrich with employee names
-    const empIds = [...new Set(result.data.map((l: any) => l.employee_id))];
+    // Enrich with employee names. Loans cut against the legacy employees
+    // table store the name there; loans cut after the EmpCloud integration
+    // store only empcloud_user_id (the employees row may not exist), so
+    // names have to come from the EmpCloud users table for those rows
+    // (#206 — admin saw "Unknown" for every loan).
+    const empIds = [...new Set(result.data.map((l: any) => l.employee_id).filter(Boolean))];
+    const userIds = [
+      ...new Set(
+        result.data
+          .map((l: any) => Number(l.empcloud_user_id))
+          .filter((n: any) => Number.isFinite(n) && n > 0),
+      ),
+    ];
+
     const empMap: Record<string, any> = {};
     for (const eid of empIds) {
-      const emp = await this.db.findById<any>("employees", eid as string);
+      const emp = await this.db.findById<any>("employees", eid as string).catch(() => null);
       if (emp) empMap[eid as string] = emp;
+    }
+
+    let userMap: Record<string, any> = {};
+    if (userIds.length > 0) {
+      try {
+        const ecDb = getEmpCloudDB();
+        const rows = await ecDb("users")
+          .whereIn("id", userIds as number[])
+          .select("id", "first_name", "last_name", "emp_code");
+        for (const u of rows) {
+          userMap[String(u.id)] = u;
+        }
+      } catch {
+        // EmpCloud DB unavailable — fall back to "Unknown"
+      }
     }
 
     return {
       ...result,
-      data: result.data.map((l: any) => ({
-        ...l,
-        employee_name: empMap[l.employee_id]
-          ? `${empMap[l.employee_id].first_name} ${empMap[l.employee_id].last_name}`
-          : "Unknown",
-        employee_code: empMap[l.employee_id]?.employee_code || "",
-      })),
+      data: result.data.map((l: any) => {
+        const emp = empMap[l.employee_id];
+        const user = l.empcloud_user_id ? userMap[String(l.empcloud_user_id)] : undefined;
+        const name = emp
+          ? `${emp.first_name} ${emp.last_name}`
+          : user
+            ? `${user.first_name} ${user.last_name}`
+            : "Unknown";
+        return {
+          ...l,
+          employee_name: name,
+          employee_code: emp?.employee_code || user?.emp_code || "",
+        };
+      }),
     };
   }
 
@@ -82,9 +117,13 @@ export class LoanService {
     const data = parsed.data;
 
     const rate = data.interestRate || 0;
-    const emi = rate > 0
-      ? Math.round((data.principalAmount * (1 + rate / 100 * data.tenureMonths / 12)) / data.tenureMonths)
-      : Math.round(data.principalAmount / data.tenureMonths);
+    const emi =
+      rate > 0
+        ? Math.round(
+            (data.principalAmount * (1 + ((rate / 100) * data.tenureMonths) / 12)) /
+              data.tenureMonths,
+          )
+        : Math.round(data.principalAmount / data.tenureMonths);
 
     return this.db.create("loans", {
       employee_id: data.employeeId,


### PR DESCRIPTION
## Summary
- Policy Number is an identifier, never negative. Reject a leading - both via an HTML pattern attribute and on submit so HR cant save a malformed id (#221).
- Loans list resolved employee_name only via the legacy employees table; loans created post EmpCloud-integration store empcloud_user_id but no employees row, so admin saw Unknown for every borrower (#206). Look up names from EmpCloud users when the legacy lookup misses.

Closes #206
Closes #221

## Test plan
- [ ] Edit Insurance Policy, type -1 in Policy Number -> blocked.
- [ ] On Loans, every row now shows the borrower name (no Unknown for post-integration loans).