### PR TITLE
fix: equal-height stat cards, salary pie chart bg, benefits cost card

### DIFF
--- a/packages/client/src/components/ui/StatCard.tsx
+++ b/packages/client/src/components/ui/StatCard.tsx
@@ -66,7 +66,10 @@ export function StatCard({
   // Cards clickable (#84 #85 #89 #91 #92 #96 #105 etc) — when `to` or
   // `onClick` is provided, render as an interactive element with a subtle
   // hover cue. focus-visible rings only (never persist after mouse click).
-  const cardBase = "rounded-xl border border-gray-200 bg-white p-6 shadow-sm transition";
+  // h-full keeps siblings the same height when one card has a short value
+  // and another has a subtitle / longer string in the same grid row
+  // (#229 Tax 'Total Employees', #232 Loans cards).
+  const cardBase = "h-full rounded-xl border border-gray-200 bg-white p-6 shadow-sm transition";
   const interactive =
     "hover:-translate-y-0.5 hover:border-brand-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500";
 

--- a/packages/client/src/pages/benefits/BenefitsPage.tsx
+++ b/packages/client/src/pages/benefits/BenefitsPage.tsx
@@ -325,11 +325,15 @@ export function BenefitsPage() {
           icon={Heart}
           onClick={() => setTab("pending")}
         />
+        {/* Monthly Employer Cost is a summary number — clicking it used to
+            jump back to Plans even when the user already had Enrollments/
+            Pending open, swapping their context for no good reason. Render
+            as a plain non-interactive card so the value is informative
+            without redirecting (#233). */}
         <StatCard
           title="Monthly Employer Cost"
           value={formatCurrency(stats.totalEmployerCost || 0)}
           icon={DollarSign}
-          onClick={() => setTab("plans")}
         />
       </div>
 

--- a/packages/client/src/pages/self-service/MySalaryPage.tsx
+++ b/packages/client/src/pages/self-service/MySalaryPage.tsx
@@ -12,15 +12,27 @@ export function MySalaryPage() {
   const { data: res, isLoading } = useMySalary();
 
   if (isLoading) {
-    return <div className="flex h-64 items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-brand-600" /></div>;
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Loader2 className="text-brand-600 h-8 w-8 animate-spin" />
+      </div>
+    );
   }
 
   const salary = res?.data;
   if (!salary) return <div className="p-8 text-gray-500">No salary information available</div>;
 
-  const components = typeof salary.components === "string" ? JSON.parse(salary.components) : salary.components || [];
+  const components =
+    typeof salary.components === "string" ? JSON.parse(salary.components) : salary.components || [];
   const pieData = components.map((c: any, i: number) => ({
-    name: c.code === "BASIC" ? "Basic Salary" : c.code === "HRA" ? "HRA" : c.code === "SA" ? "Special Allowance" : c.code,
+    name:
+      c.code === "BASIC"
+        ? "Basic Salary"
+        : c.code === "HRA"
+          ? "HRA"
+          : c.code === "SA"
+            ? "Special Allowance"
+            : c.code,
     value: c.monthlyAmount,
     color: COLORS[i % COLORS.length],
   }));
@@ -31,7 +43,9 @@ export function MySalaryPage() {
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <Card>
-          <CardHeader><CardTitle>Annual Summary</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle>Annual Summary</CardTitle>
+          </CardHeader>
           <CardContent>
             <dl className="space-y-3">
               {[
@@ -52,25 +66,52 @@ export function MySalaryPage() {
         </Card>
 
         <Card className="lg:col-span-2">
-          <CardHeader><CardTitle>Monthly Salary Breakdown</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle>Monthly Salary Breakdown</CardTitle>
+          </CardHeader>
           <CardContent>
             <div className="flex items-center gap-8">
               <div className="h-56 w-56">
                 <ResponsiveContainer width="100%" height="100%">
                   <PieChart>
-                    <Pie data={pieData} dataKey="value" cx="50%" cy="50%" innerRadius={50} outerRadius={80}>
+                    {/* activeIndex=-1 disables recharts' default click-active
+                        sector, which was rendering an extra translucent
+                        rectangle behind the slice when clicked (#211).
+                        isAnimationActive=false also keeps the chart
+                        from briefly resizing on rerender. */}
+                    <Pie
+                      data={pieData}
+                      dataKey="value"
+                      cx="50%"
+                      cy="50%"
+                      innerRadius={50}
+                      outerRadius={80}
+                      activeIndex={-1}
+                      isAnimationActive={false}
+                    >
                       {pieData.map((entry: any, i: number) => (
                         <Cell key={i} fill={entry.color} />
                       ))}
                     </Pie>
-                    <Tooltip formatter={(v: number) => formatCurrency(v)} />
+                    <Tooltip
+                      formatter={(v: number) => formatCurrency(v)}
+                      cursor={false}
+                      contentStyle={{
+                        borderRadius: 8,
+                        border: "1px solid rgb(229 231 235)",
+                        boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
+                      }}
+                    />
                   </PieChart>
                 </ResponsiveContainer>
               </div>
               <div className="space-y-2">
                 {pieData.map((item: any) => (
                   <div key={item.name} className="flex items-center gap-2 text-sm">
-                    <span className="h-3 w-3 rounded-full" style={{ backgroundColor: item.color }} />
+                    <span
+                      className="h-3 w-3 rounded-full"
+                      style={{ backgroundColor: item.color }}
+                    />
                     <span className="text-gray-600">{item.name}</span>
                     <span className="ml-auto font-medium">{formatCurrency(item.value)}</span>
                   </div>
@@ -100,9 +141,21 @@ export function MySalaryPage() {
             <tbody className="divide-y divide-gray-50">
               {components.map((c: any) => (
                 <tr key={c.code}>
-                  <td className="py-2 text-gray-900">{c.code === "BASIC" ? "Basic Salary" : c.code === "HRA" ? "HRA" : c.code === "SA" ? "Special Allowance" : c.code}</td>
-                  <td className="py-2 text-right text-gray-900">{formatCurrency(c.monthlyAmount)}</td>
-                  <td className="py-2 text-right text-gray-900">{formatCurrency(c.annualAmount)}</td>
+                  <td className="py-2 text-gray-900">
+                    {c.code === "BASIC"
+                      ? "Basic Salary"
+                      : c.code === "HRA"
+                        ? "HRA"
+                        : c.code === "SA"
+                          ? "Special Allowance"
+                          : c.code}
+                  </td>
+                  <td className="py-2 text-right text-gray-900">
+                    {formatCurrency(c.monthlyAmount)}
+                  </td>
+                  <td className="py-2 text-right text-gray-900">
+                    {formatCurrency(c.annualAmount)}
+                  </td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## Summary
- StatCard had no h-full so cards with a short value (count) rendered shorter than siblings with a long currency value or subtitle in the same grid row. Add h-full to cardBase (#229 Tax, #232 Loans).
- My Salary pie chart left a translucent rectangle behind a slice on click (recharts default activeIndex). Disable it (activeIndex=-1), turn off resize animation, and tighten Tooltip styling (#211).
- Benefits Monthly Employer Cost is informational; clicking it swapped the user back to Plans even from other tabs. Render as a non-interactive card (#233).

Closes #211
Closes #229
Closes #232
Closes #233

## Test plan
- [ ] Tax page Total Employees card matches sibling heights.
- [ ] Loans page card sizes line up.
- [ ] My Salary pie chart slice clicks no longer paint a stray rectangle.
- [ ] Benefits Monthly Employer Cost card no longer redirects.