### PR TITLE
fix: misc - advance salary, terminated icon, country dropdown, currency, attendance

### DIFF
--- a/packages/client/src/pages/attendance/AttendancePage.tsx
+++ b/packages/client/src/pages/attendance/AttendancePage.tsx
@@ -171,6 +171,12 @@ export function AttendancePage() {
               toast.error("Working days must be a whole number between 1 and 31");
               return;
             }
+            if (employees.length === 0) {
+              toast.error(
+                "No employees found in payroll. Apply EmpCloud users to payroll first (Settings > Employees).",
+              );
+              return;
+            }
             setMarking(true);
             try {
               const records = employees.map((emp: any) => ({

--- a/packages/client/src/pages/global-payroll/ContractorInvoicesPage.tsx
+++ b/packages/client/src/pages/global-payroll/ContractorInvoicesPage.tsx
@@ -55,6 +55,11 @@ export function ContractorInvoicesPage() {
     label: `${c.first_name} ${c.last_name} (${c.country_name})`,
   }));
 
+  // Resolve the selected contractor's currency so the amount input can
+  // show its symbol/code instead of a bare number (#217).
+  const selectedContractor = contractors.find((c: any) => c.id === form.globalEmployeeId);
+  const amountCurrency = selectedContractor?.currency_symbol || selectedContractor?.currency || "";
+
   const handleSubmit = async () => {
     if (!form.globalEmployeeId || !form.amount || !form.periodStart || !form.periodEnd) {
       toast.error("Please fill all required fields");
@@ -275,14 +280,26 @@ export function ContractorInvoicesPage() {
             onChange={(e) => setForm({ ...form, globalEmployeeId: e.target.value })}
             disabled={contractorOptions.length === 0}
           />
-          <Input
-            label="Amount * (in major currency unit)"
-            type="number"
-            min="0"
-            step="0.01"
-            value={form.amount}
-            onChange={(e) => setForm({ ...form, amount: e.target.value })}
-          />
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">
+              Amount <span className="text-red-500">*</span>{" "}
+              <span className="text-xs font-normal text-gray-400">(major currency unit)</span>
+            </label>
+            <div className="flex">
+              <span className="inline-flex w-14 items-center justify-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-sm font-medium text-gray-600">
+                {amountCurrency || "—"}
+              </span>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={form.amount}
+                onChange={(e) => setForm({ ...form, amount: e.target.value })}
+                className="focus:border-brand-500 focus:ring-brand-500 block w-full rounded-r-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1"
+                placeholder="0.00"
+              />
+            </div>
+          </div>
           <div className="grid grid-cols-2 gap-4">
             <Input
               label="Period Start *"

--- a/packages/client/src/pages/global-payroll/GlobalEmployeesPage.tsx
+++ b/packages/client/src/pages/global-payroll/GlobalEmployeesPage.tsx
@@ -353,24 +353,31 @@ export function GlobalEmployeesPage() {
           >
             <Pencil className="h-3.5 w-3.5" />
           </Button>
-          {row.status !== "terminated" && (
-            <Button
-              variant="ghost"
-              size="sm"
-              title="Terminate employee"
-              disabled={terminatingId === row.id}
-              onClick={(e) => {
-                e.stopPropagation();
-                handleTerminate(row);
-              }}
-            >
-              {terminatingId === row.id ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <UserX className="h-3.5 w-3.5 text-red-500" />
-              )}
-            </Button>
-          )}
+          {/* Keep the terminate icon visible after termination but disabled,
+              instead of hiding it. The empty action column made the row
+              look broken / inconsistent vs other rows (#209). */}
+          <Button
+            variant="ghost"
+            size="sm"
+            title={
+              row.status === "terminated" ? "Employee already terminated" : "Terminate employee"
+            }
+            disabled={row.status === "terminated" || terminatingId === row.id}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (row.status !== "terminated") handleTerminate(row);
+            }}
+          >
+            {terminatingId === row.id ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <UserX
+                className={`h-3.5 w-3.5 ${
+                  row.status === "terminated" ? "text-gray-300" : "text-red-500"
+                }`}
+              />
+            )}
+          </Button>
         </div>
       ),
     },

--- a/packages/client/src/pages/global-payroll/GlobalPayrollRunsPage.tsx
+++ b/packages/client/src/pages/global-payroll/GlobalPayrollRunsPage.tsx
@@ -78,18 +78,15 @@ export function GlobalPayrollRunsPage() {
   const runs = runsRes?.data || [];
   const runDetail = detailRes?.data;
 
-  // Country IDs where we have at least one active EOR or direct-hire
-  // employee — those are the only countries the backend will accept for
-  // a Create Run (#154).
+  // Country IDs where we have at least one active employee. Originally
+  // narrowed to EOR/direct-hire only (#154), but that excluded countries
+  // where the org had only contractors and meant 'India' was the only
+  // pickable option for orgs with non-Indian contractors (#210). Show
+  // every country with any active global employee; the backend still
+  // returns a clear error if the country has no payable employees.
   const globalEmployees: any[] = globalEmployeesRes?.data || [];
   const payableCountryIds = new Set(
-    globalEmployees
-      .filter(
-        (e) =>
-          e.status === "active" &&
-          (e.employment_type === "eor" || e.employment_type === "direct_hire"),
-      )
-      .map((e) => e.country_id),
+    globalEmployees.filter((e) => e.status === "active").map((e) => e.country_id),
   );
 
   const countryOptions = countries

--- a/packages/server/src/services/earned-wage.service.ts
+++ b/packages/server/src/services/earned-wage.service.ts
@@ -78,17 +78,39 @@ export class EarnedWageService {
       };
     }
 
-    // Get employee's current salary assignment
-    const salaryAssignment = await this.db.findOne<any>("salary_assignments", {
-      employee_id: employeeId,
-      org_id: numOrgId,
-    });
+    // Get employee's current salary. Try the legacy salary_assignments
+    // table first (UUID employee_id keyed), then fall back to
+    // employee_salaries which is keyed on empcloud_user_id — the EmpCloud
+    // integration writes to the latter, so without this fallback users
+    // onboarded via the new flow always get "No salary assigned"
+    // and "Unable to request advanced salary" (#208).
+    let ctc: number | null = null;
+    const salaryAssignment = await this.db
+      .findOne<any>("salary_assignments", {
+        employee_id: employeeId,
+        org_id: numOrgId,
+      })
+      .catch(() => null);
+    if (salaryAssignment) {
+      ctc = Number(salaryAssignment.ctc);
+    } else {
+      const numericEmpId = Number(employeeId);
+      if (Number.isFinite(numericEmpId) && numericEmpId > 0) {
+        const empSalary = await this.db
+          .findOne<any>("employee_salaries", {
+            empcloud_user_id: numericEmpId,
+            is_active: 1,
+          })
+          .catch(() => null);
+        if (empSalary) ctc = Number(empSalary.ctc);
+      }
+    }
 
-    if (!salaryAssignment) {
+    if (!ctc || ctc <= 0) {
       return { available: 0, earnedSoFar: 0, alreadyWithdrawn: 0, message: "No salary assigned" };
     }
 
-    const monthlySalary = Number(salaryAssignment.ctc) / 12;
+    const monthlySalary = ctc / 12;
 
     // Calculate days worked this month
     const now = new Date();


### PR DESCRIPTION
## Summary
- Earned wage advance failed with No salary assigned for anyone whose salary lives in employee_salaries (the EmpCloud-integrated table) rather than legacy salary_assignments. Fall back to the new table so advance works for users onboarded via the new flow (#208).
- Global employees terminate icon used to disappear after termination, leaving a broken-looking row vs siblings. Render it always and disable when status===terminated (#209).
- Global Payroll Run create-form country picker filtered to EOR/direct_hire only, leaving India as the only option for orgs whose non-Indian workforce is contractors. Loosen to any country with an active employee; backend still validates payable employees per country (#210).
- Contractor invoice Amount input now shows a leading currency symbol/code resolved from the picked contractor (#217).
- Mark All Present silently no-oped when no payroll-seated employees existed; surface a clear toast pointing to the import flow (#231).

Closes #208
Closes #209
Closes #210
Closes #217
Closes #231

## Test plan
- [ ] Request advance for an EmpCloud-integrated user with salary -> succeeds.
- [ ] After terminating a global employee, the cross icon stays visible but disabled.
- [ ] Create payroll run -> picker offers all countries that have any active employee.
- [ ] Submit invoice modal -> currency code shows in the addon next to amount.
- [ ] Mark All Present with no employees -> toast points to the import flow.