### PR TITLE
fix: dashboard pie bg, leaves total breakdown, PAN fallback, missing-field dash

### DIFF
--- a/packages/client/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/client/src/pages/dashboard/DashboardPage.tsx
@@ -245,6 +245,9 @@ export function DashboardPage() {
             <div className="h-64">
               <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
+                  {/* activeIndex=-1 + cursor=false suppress recharts'
+                      default click highlight, which painted a translucent
+                      rectangle behind the active slice (#252). */}
                   <Pie
                     data={departmentHeadcount}
                     dataKey="count"
@@ -253,13 +256,21 @@ export function DashboardPage() {
                     cy="45%"
                     outerRadius={60}
                     innerRadius={30}
+                    activeIndex={-1}
+                    isAnimationActive={false}
                   >
                     {departmentHeadcount.map((_, i) => (
                       <Cell key={i} fill={COLORS[i % COLORS.length]} />
                     ))}
                   </Pie>
                   <Tooltip
+                    cursor={false}
                     formatter={(value: number, name: string) => [`${value} employees`, name]}
+                    contentStyle={{
+                      borderRadius: 8,
+                      border: "1px solid rgb(229 231 235)",
+                      boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
+                    }}
                   />
                   <Legend
                     layout="horizontal"

--- a/packages/client/src/pages/self-service/MyLeavesPage.tsx
+++ b/packages/client/src/pages/self-service/MyLeavesPage.tsx
@@ -27,6 +27,7 @@ export function MyLeavesPage() {
   const [filter, setFilter] = useState("all");
   const [tab, setTab] = useState<"my" | "team">("my");
   const [teamFilter, setTeamFilter] = useState("pending");
+  const [showUsedBreakdown, setShowUsedBreakdown] = useState(false);
   // Controlled form state for the Apply Leave modal. Using a useState object
   // (instead of reading from FormData on submit) makes client-side validation
   // and field-clearing between submits straightforward. (#37)
@@ -269,12 +270,24 @@ export function MyLeavesPage() {
                 <p className="text-2xl font-bold text-blue-600">{totalAvailable}</p>
               </CardContent>
             </Card>
-            <Card>
-              <CardContent className="p-4 text-center">
-                <p className="text-sm text-gray-500 dark:text-gray-400">Total Used</p>
-                <p className="text-2xl font-bold text-orange-600">{totalUsed}</p>
-              </CardContent>
-            </Card>
+            {/* Total Used is clickable — opens a breakdown of which leave
+                types contributed to the total (#238). */}
+            <button
+              type="button"
+              onClick={() => setShowUsedBreakdown(true)}
+              className="text-left transition hover:-translate-y-0.5"
+              title="See breakdown by leave type"
+            >
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Total Used</p>
+                  <p className="text-2xl font-bold text-orange-600">{totalUsed}</p>
+                  <p className="mt-1 text-[10px] uppercase tracking-wide text-gray-400">
+                    Click for breakdown
+                  </p>
+                </CardContent>
+              </Card>
+            </button>
             {balances.map((b: any) => (
               <Card key={b.leave_type}>
                 <CardContent className="p-4 text-center">
@@ -660,6 +673,64 @@ export function MyLeavesPage() {
             </Button>
           </div>
         </form>
+      </Modal>
+
+      {/* Total Used breakdown — populated from the same balance rows the
+          Total Used card sums, so it always matches the headline number
+          (#238). */}
+      <Modal
+        open={showUsedBreakdown}
+        onClose={() => setShowUsedBreakdown(false)}
+        title="Leaves used — breakdown by type"
+      >
+        {balances.length === 0 || totalUsed === 0 ? (
+          <p className="py-4 text-center text-sm text-gray-500">
+            You haven't used any leave yet this period.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <table className="w-full text-sm">
+              <thead className="border-b text-left text-xs uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th className="pb-2 font-medium">Type</th>
+                  <th className="pb-2 text-right font-medium">Used</th>
+                  <th className="pb-2 text-right font-medium">Accrued</th>
+                  <th className="pb-2 text-right font-medium">% of total</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                {balances
+                  .filter((b: any) => Number(b.used) > 0)
+                  .sort((a: any, b: any) => Number(b.used) - Number(a.used))
+                  .map((b: any) => {
+                    const used = Number(b.used);
+                    const pct = totalUsed > 0 ? Math.round((used / totalUsed) * 100) : 0;
+                    return (
+                      <tr key={b.leave_type}>
+                        <td className="py-2 capitalize">
+                          {String(b.leave_type).replace(/_/g, " ")}
+                        </td>
+                        <td className="py-2 text-right font-medium text-orange-600">{used}</td>
+                        <td className="py-2 text-right text-gray-500">{Number(b.accrued)}</td>
+                        <td className="py-2 text-right text-gray-500">{pct}%</td>
+                      </tr>
+                    );
+                  })}
+                <tr className="border-t font-semibold">
+                  <td className="py-2">Total</td>
+                  <td className="py-2 text-right text-orange-600">{totalUsed}</td>
+                  <td className="py-2"></td>
+                  <td className="py-2 text-right text-gray-400">100%</td>
+                </tr>
+              </tbody>
+            </table>
+            <div className="flex justify-end pt-2">
+              <Button variant="outline" onClick={() => setShowUsedBreakdown(false)}>
+                Close
+              </Button>
+            </div>
+          </div>
+        )}
       </Modal>
 
       {/* Cancel Leave Modal */}

--- a/packages/client/src/pages/self-service/MyProfilePage.tsx
+++ b/packages/client/src/pages/self-service/MyProfilePage.tsx
@@ -106,12 +106,17 @@ export function MyProfilePage() {
               ["Employee Code", emp.employee_code],
               ["Department", emp.department],
               ["Designation", emp.designation],
-              ["Employment Type", (emp.employment_type || "full_time").replace("_", " ")],
-              ["Date of Joining", formatDate(emp.date_of_joining)],
+              ["Employment Type", emp.employment_type ? emp.employment_type.replace("_", " ") : ""],
+              ["Date of Joining", emp.date_of_joining ? formatDate(emp.date_of_joining) : ""],
             ].map(([label, value]) => (
               <div key={label}>
                 <dt className="text-sm text-gray-500">{label}</dt>
-                <dd className="mt-1 text-sm font-medium capitalize text-gray-900">{value}</dd>
+                {/* Show an em-dash for missing values so the field reads as
+                    "not set" instead of silently rendering blank or, worse,
+                    a default like "HR" the user never entered (#250). */}
+                <dd className="mt-1 text-sm font-medium capitalize text-gray-900">
+                  {value || "—"}
+                </dd>
               </div>
             ))}
           </dl>

--- a/packages/server/src/db/empcloud.ts
+++ b/packages/server/src/db/empcloud.ts
@@ -156,6 +156,38 @@ export async function getUserDepartmentName(departmentId: number | null): Promis
 }
 
 /**
+ * Statutory IDs (PAN, Aadhar, passport) live on EmpCloud's
+ * `employee_profiles` table — separate from the `users` row but tied to
+ * it via `user_id`. emp-payroll needs them so PAN/Aadhar entered in the
+ * EmpCloud profile show up on the payroll-side My Profile (#251).
+ *
+ * Returns null when the row doesn't exist (employee never opened their
+ * EmpCloud profile / hasn't filled it in yet) so the caller can fall
+ * through to whatever the payroll DB has.
+ */
+export interface EmpCloudEmployeeProfile {
+  pan_number: string | null;
+  aadhar_number: string | null;
+  passport_number: string | null;
+}
+
+export async function findEmployeeProfileByUserId(
+  userId: number,
+): Promise<EmpCloudEmployeeProfile | null> {
+  const db = getEmpCloudDB();
+  try {
+    const row = await db("employee_profiles")
+      .where({ user_id: userId })
+      .select("pan_number", "aadhar_number", "passport_number")
+      .first();
+    return row || null;
+  } catch {
+    // The table may not exist on older EmpCloud schemas; degrade gracefully.
+    return null;
+  }
+}
+
+/**
  * Find all users in an organization (active only).
  */
 export async function findUsersByOrgId(

--- a/packages/server/src/services/employee.service.ts
+++ b/packages/server/src/services/employee.service.ts
@@ -15,6 +15,7 @@ import {
   findUnseatedUsersForModule,
   getUserDepartmentName,
   getEmpCloudDB,
+  findEmployeeProfileByUserId,
   EmpCloudUser,
 } from "../db/empcloud";
 import { v4 as uuidv4 } from "uuid";
@@ -40,6 +41,19 @@ async function mergeUserWithProfile(ecUser: EmpCloudUser, payrollDb: any): Promi
       ? JSON.parse(profile.tax_info || "{}")
       : profile.tax_info
     : {};
+
+  // PAN / Aadhar are entered on EmpCloud's profile screen (employee_profiles
+  // table). The payroll-side tax_info JSON may have been written by an HR
+  // admin via the payroll detail page, but if the employee filled their
+  // statutory IDs in EmpCloud first, the payroll merge previously ignored
+  // them and surfaced "—" on the My Profile screen. Fall through to the
+  // EmpCloud employee_profiles row when tax_info is missing the field
+  // (#251).
+  const ecStatutory = await findEmployeeProfileByUserId(ecUser.id);
+  if (ecStatutory) {
+    if (!taxInfo.pan && ecStatutory.pan_number) taxInfo.pan = ecStatutory.pan_number;
+    if (!taxInfo.aadhar && ecStatutory.aadhar_number) taxInfo.aadhar = ecStatutory.aadhar_number;
+  }
   const pfDetails = profile
     ? typeof profile.pf_details === "string"
       ? JSON.parse(profile.pf_details || "{}")


### PR DESCRIPTION
## Summary
- Headcount by Department pie chart on the admin dashboard left a stray rectangle behind the active slice on click. Disable activeIndex/animation + Tooltip cursor (#252) — same pattern already applied to MySalary.
- My Leaves Total Used card is now a button; clicking opens a breakdown modal listing every leave type with non-zero used days, accrued, and percentage of total (#238). Reads from the same /leaves/my-balance payload so totals always match.
- mergeUserWithProfile now reads PAN/Aadhar from EmpCloud employee_profiles and falls them through to taxInfo when the payroll-side tax_info JSON does not have them. Previously the employee-side My Profile only read tax_info.pan, so PAN entered on EmpCloud never reflected on the payroll side (#251).
- MyProfilePage Employment block now renders an em-dash for unset Department/Designation/etc. instead of blank, and stops hard-coding full_time for null employment_type (defensive for #250).

Closes #238
Closes #252
Refs #250
Refs #251

## Test plan
- [ ] Click any slice on the admin Headcount pie -> no stray rectangle painted behind it.
- [ ] On My Leaves, click the Total Used card -> modal lists CL/SL/EL etc. with used count and percentage; numbers sum to the headline.
- [ ] Set PAN on the EmpCloud profile, then open emp-payroll My Profile -> Statutory Details now shows the PAN value (was —).
- [ ] Open My Profile for a user with no department in EmpCloud -> Department reads — (the EmpCloud-side dropdown fix lives in the EmpCloud companion PR).