### PR TITLE
fix(reimbursements): admin list missed claims from new-flow employees

### DIFF
--- a/packages/server/src/services/reimbursement.service.ts
+++ b/packages/server/src/services/reimbursement.service.ts
@@ -28,9 +28,14 @@ export class ReimbursementService {
       filters: { org_id: orgId, is_active: true },
       limit: 10000,
     });
+    // #273 — `employee_payroll_profiles` uses `empcloud_org_id` (numeric),
+    // not `org_id` (the legacy uuid column on the old `employees` table).
+    // The old filter silently returned no rows because the column doesn't
+    // exist on this table, so any employee onboarded via the new flow had
+    // their reimbursements invisible in the admin list.
     const profiles = await this.db
       .findMany<any>("employee_payroll_profiles", {
-        filters: { org_id: orgId, is_active: 1 },
+        filters: { empcloud_org_id: Number(orgId), is_active: 1 },
         limit: 10000,
       })
       .catch(() => ({ data: [] as any[] }));


### PR DESCRIPTION
## Summary

Closes #273. Admin reimbursements list was empty for any employee onboarded via the new EmpCloud-integrated flow because of a column-name mismatch in the org-scoped lookup.

## Root cause

`ReimbursementService.list()` builds an `empMap` from two sources:
- Legacy `employees` table — filtered by `org_id` (uuid)
- Current `employee_payroll_profiles` — filtered by `org_id` ❌

But `employee_payroll_profiles` uses `empcloud_org_id` (a `bigInteger`), not `org_id`. The mismatched query threw, got swallowed by `.catch(() => ({ data: [] }))`, and `empMap` ended up containing only legacy rows. Reimbursements were then queried with `WHERE employee_id IN (legacy_only_ids)`, so claims from new-flow employees were silently filtered out.

## Fix

One-line: use `empcloud_org_id: Number(orgId)` for the profiles lookup. The route already passes `req.user!.empcloudOrgId` (numeric) so `Number()` is just defensive.

## Test plan

- [ ] As a new-flow employee, submit a reimbursement claim via My Reimbursements → Apply.
- [ ] As HR admin, navigate to /reimbursements → claim appears in the table.
- [ ] Filter by status, employee, etc. — all work.
- [ ] Approve/reject buttons still work.