### PR TITLE
feat(employees,tax): PAN format + uniqueness + Section 206AA flat 20%

### DIFF
--- a/packages/client/src/pages/employees/EmployeeCreatePage.tsx
+++ b/packages/client/src/pages/employees/EmployeeCreatePage.tsx
@@ -74,9 +74,25 @@ export function EmployeeCreatePage() {
       return;
     }
 
+    // #1656 — Indian PAN format AAAAA9999A. Server re-validates; this
+    // gives an immediate, in-form error instead of a 400 from the API.
+    const panRaw = get("pan").trim().toUpperCase();
+    if (panRaw && !/^[A-Z]{5}[0-9]{4}[A-Z]$/.test(panRaw)) {
+      toast.error("PAN must match the format AAAAA9999A");
+      return;
+    }
+
+    // #1658 — emp_code permissive: letters, digits, dots, dashes,
+    // underscores. Whitespace and other punctuation rejected.
+    const empCode = get("employee_id").trim();
+    if (empCode && !/^[A-Za-z0-9._-]+$/.test(empCode)) {
+      toast.error("Employee code may only contain letters, digits, dots, dashes or underscores");
+      return;
+    }
+
     try {
       await mutation.mutateAsync({
-        employeeCode: get("employee_id"),
+        employeeCode: empCode,
         firstName: get("first_name"),
         lastName: get("last_name"),
         email: get("email"),
@@ -94,7 +110,7 @@ export function EmployeeCreatePage() {
           branchName: "",
         },
         taxInfo: {
-          pan: get("pan"),
+          pan: panRaw,
           regime: get("tax_regime") || "new",
           uan: get("uan") || undefined,
         },
@@ -194,6 +210,9 @@ export function EmployeeCreatePage() {
                 name="employee_id"
                 label="Employee ID"
                 placeholder="EMP009"
+                pattern="[A-Za-z0-9._\-]+"
+                title="Letters, digits, dots, dashes or underscores only"
+                maxLength={50}
                 required
               />
               {/* #48 — Department dropdown populated from the org's
@@ -286,7 +305,17 @@ export function EmployeeCreatePage() {
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
-              <Input id="pan" name="pan" label="PAN Number" placeholder="ABCPS1234F" required />
+              <Input
+                id="pan"
+                name="pan"
+                label="PAN Number"
+                placeholder="ABCPS1234F"
+                pattern="[A-Za-z]{5}[0-9]{4}[A-Za-z]"
+                title="PAN must match the format AAAAA9999A"
+                maxLength={10}
+                style={{ textTransform: "uppercase" }}
+                required
+              />
               <Input id="uan" name="uan" label="UAN / PF Number" placeholder="BGBNG/12345/009" />
               <SelectField
                 id="tax_regime"

--- a/packages/client/src/pages/tax/TaxOverviewPage.tsx
+++ b/packages/client/src/pages/tax/TaxOverviewPage.tsx
@@ -6,7 +6,12 @@ import { Badge } from "@/components/ui/Badge";
 import { DataTable } from "@/components/ui/DataTable";
 import { formatCurrency } from "@/lib/utils";
 import { useEmployees } from "@/api/hooks";
-import { Calculator, FileText, IndianRupee, Users, Loader2 } from "lucide-react";
+import { Calculator, FileText, IndianRupee, Users, Loader2, AlertTriangle } from "lucide-react";
+
+// #1657 — Indian PAN format. Anything that doesn't match (or empty) is
+// treated as "missing for compliance purposes" — Section 206AA flat 20%
+// kicks in at TDS calc time and the row gets flagged in the table.
+const PAN_RE = /^[A-Z]{5}[0-9]{4}[A-Z]$/;
 
 export function TaxOverviewPage() {
   const { data: res, isLoading } = useEmployees({ limit: 1000 });
@@ -18,14 +23,19 @@ export function TaxOverviewPage() {
 
   const allTaxData = employees.map((e: any) => {
     const taxInfo = typeof e.tax_info === "string" ? JSON.parse(e.tax_info) : e.tax_info || {};
+    const rawPan = typeof taxInfo.pan === "string" ? taxInfo.pan.trim() : "";
+    const panValid = PAN_RE.test(rawPan);
     return {
       ...e,
-      pan: taxInfo.pan || "—",
+      pan: rawPan || "—",
+      panValid,
       regime: taxInfo.regime || "new",
       estimated_tax: Math.round((Number(e.ctc || 0) || 1200000) * 0.12),
       tds_deducted: Math.round((Number(e.ctc || 0) || 1200000) * 0.12 * (3 / 12)),
     };
   });
+
+  const missingPanCount = allTaxData.filter((e: any) => !e.panValid).length;
 
   const totalEstimatedTax = allTaxData.reduce((s: number, e: any) => s + e.estimated_tax, 0);
   const totalTdsDeducted = allTaxData.reduce((s: number, e: any) => s + e.tds_deducted, 0);
@@ -45,8 +55,20 @@ export function TaxOverviewPage() {
           <p className="font-medium text-gray-900">
             {row.first_name} {row.last_name}
           </p>
-          <p className="text-xs text-gray-500">
-            {row.employee_code} &middot; PAN: {row.pan}
+          <p className="flex items-center gap-2 text-xs text-gray-500">
+            <span>
+              {row.employee_code} &middot; PAN: {row.pan}
+            </span>
+            {/* #1657 — flag rows where PAN is missing or malformed; they
+                trigger Section 206AA flat 20% TDS in the calc engine. */}
+            {!row.panValid && (
+              <span
+                title="No valid PAN — TDS deducted at Section 206AA flat 20%."
+                className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800"
+              >
+                <AlertTriangle className="h-3 w-3" /> No PAN
+              </span>
+            )}
           </p>
         </div>
       ),
@@ -75,6 +97,24 @@ export function TaxOverviewPage() {
   return (
     <div className="space-y-6">
       <PageHeader title="Tax Overview" description="FY 2025-26 income tax summary" />
+
+      {/* #1657 — banner highlighting the count of employees missing a valid
+          PAN, since each one is being TDS'd at Section 206AA flat 20%
+          until they enter their details. */}
+      {missingPanCount > 0 && (
+        <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600" />
+          <div>
+            <p className="font-medium">
+              {missingPanCount} employee{missingPanCount === 1 ? "" : "s"} without a valid PAN
+            </p>
+            <p className="mt-1 text-amber-800">
+              TDS for these employees is being deducted at the Section 206AA flat rate of 20%. Ask
+              each employee to update their PAN in their profile so standard slab rates apply.
+            </p>
+          </div>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
         <Link to="/tax" className="block transition-transform hover:scale-[1.02]">

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -105,7 +105,21 @@ const bankNameSchema = z
 
 export const createEmployeeSchema = z.object({
   body: z.object({
-    employeeCode: z.string().min(1).max(50).optional(),
+    // #1658 — emp_code is permissive on format (orgs use widely different
+    // conventions — letters, numbers, dots, dashes, underscores) but must
+    // not contain whitespace or control characters and must not be empty
+    // after trimming. Uniqueness is enforced at the EmpCloud users table
+    // (separate PR).
+    employeeCode: z
+      .string()
+      .trim()
+      .min(1)
+      .max(50)
+      .regex(
+        /^[A-Za-z0-9._-]+$/,
+        "Employee code may only contain letters, digits, dots, dashes or underscores",
+      )
+      .optional(),
     firstName: firstNameSchema,
     lastName: lastNameSchema,
     email: z.string().email(),
@@ -127,7 +141,13 @@ export const createEmployeeSchema = z.object({
       .optional(),
     taxInfo: z
       .object({
-        pan: z.string().min(1).max(10),
+        // #1656 — Indian PAN format AAAAA9999A. Empty/missing is allowed
+        // (the tax engine applies Section 206AA flat 20% in that case),
+        // but if a value is provided it must match.
+        pan: z
+          .string()
+          .regex(/^[A-Z]{5}[0-9]{4}[A-Z]$/, "PAN must match the format AAAAA9999A")
+          .optional(),
         regime: z.enum(["old", "new"]).default("new"),
         uan: z.string().optional(),
       })
@@ -260,7 +280,12 @@ export const bulkSalaryAssignSchema = z.object({
           // when those columns are present; bulkAssignSalary merges them
           // into the existing payroll profile (read-merge-write so a
           // partial CSV doesn't clobber other fields).
-          pan: z.string().trim().min(1).optional(),
+          // #1656 — PAN must match the Indian format when provided.
+          pan: z
+            .string()
+            .trim()
+            .regex(/^[A-Z]{5}[0-9]{4}[A-Z]$/, "PAN must match the format AAAAA9999A")
+            .optional(),
           pfDetails: z
             .object({
               pfNumber: z.string().trim().min(1).optional(),

--- a/packages/server/src/db/migrations/sql/026_pan_number_column_and_unique.ts
+++ b/packages/server/src/db/migrations/sql/026_pan_number_column_and_unique.ts
@@ -1,0 +1,72 @@
+// =============================================================================
+// MIGRATION 026 — PAN number column + UNIQUE(empcloud_org_id, pan_number)
+//
+// Pre-req: migration 025 has cleaned the dataset (no duplicates, no
+// invalid-format PANs).
+//
+// PAN was previously stored only inside the `tax_info` JSONB blob, which
+// can't carry a UNIQUE constraint or a CHECK. Two real production bugs:
+//   - EmpCloud/EmpCloud#1656: three employees in one org with PAN
+//     BLAPH256H — illegal under Indian income-tax rules.
+//   - EmpCloud/EmpCloud#1657: TDS deducted on employees with no PAN at
+//     standard rate instead of Section 206AA flat 20%.
+//
+// We add a STORED GENERATED column that's always kept in lockstep with
+// `tax_info.pan` by the database engine. App code keeps writing to
+// tax_info; the generated column updates automatically. The UNIQUE
+// constraint then enforces "one PAN per org" at the storage layer
+// without any dual-write logic in services.
+//
+// VARCHAR(32) gives headroom for the migration-025 dedup suffix
+// "BLAPH0001Z-DUP-aaaaaaaa" (23 chars).
+//
+// MySQL-only — generated columns of this shape are an 8.0+ feature.
+// Idempotent: skips if column / index already exist.
+// =============================================================================
+
+import type { Knex } from "knex";
+
+export async function up(knex: Knex) {
+  if (!(await knex.schema.hasTable("employee_payroll_profiles"))) return;
+
+  if (!(await knex.schema.hasColumn("employee_payroll_profiles", "pan_number"))) {
+    await knex.raw(`
+      ALTER TABLE employee_payroll_profiles
+      ADD COLUMN pan_number VARCHAR(32)
+      GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(tax_info, '$.pan'))) STORED
+    `);
+  }
+
+  // Unique index on (empcloud_org_id, pan_number). MySQL allows multiple
+  // NULLs in a UNIQUE index, so employees who haven't entered a PAN don't
+  // collide — they go through the Section 206AA branch in the tax engine.
+  const idx = await knex.raw(
+    `SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+       WHERE table_schema = DATABASE()
+         AND table_name = 'employee_payroll_profiles'
+         AND index_name = 'idx_emp_payroll_profiles_org_pan_uniq'`,
+  );
+  // mysql2 returns [rows, fields]; rows is empty if the index doesn't exist
+  const exists = Array.isArray(idx[0]) && idx[0].length > 0;
+  if (!exists) {
+    await knex.raw(`
+      CREATE UNIQUE INDEX idx_emp_payroll_profiles_org_pan_uniq
+        ON employee_payroll_profiles (empcloud_org_id, pan_number)
+    `);
+  }
+}
+
+export async function down(knex: Knex) {
+  if (!(await knex.schema.hasTable("employee_payroll_profiles"))) return;
+
+  // Index must be dropped before the generated column it references.
+  await knex
+    .raw(`DROP INDEX idx_emp_payroll_profiles_org_pan_uniq ON employee_payroll_profiles`)
+    .catch(() => {});
+
+  if (await knex.schema.hasColumn("employee_payroll_profiles", "pan_number")) {
+    await knex.schema.alterTable("employee_payroll_profiles", (t) => {
+      t.dropColumn("pan_number");
+    });
+  }
+}

--- a/packages/server/src/services/payroll.service.ts
+++ b/packages/server/src/services/payroll.service.ts
@@ -291,6 +291,9 @@ export class PayrollService {
         employeePfAnnual: basicMonthly * 0.12 * 12,
         monthsWorked: monthsRemaining,
         taxAlreadyPaid: 0,
+        // #1657 — Section 206AA: when PAN is missing, the tax engine
+        // applies a flat 20% rate. Empty / null pan triggers that branch.
+        panNumber: typeof taxInfo?.pan === "string" ? taxInfo.pan : null,
       });
 
       if (taxResult.monthlyTds > 0) {

--- a/packages/server/src/services/tax/india-tax.service.ts
+++ b/packages/server/src/services/tax/india-tax.service.ts
@@ -4,15 +4,26 @@
 // ============================================================================
 
 import {
-  TAX_SLABS_OLD, TAX_SLABS_NEW,
-  STANDARD_DEDUCTION_OLD, STANDARD_DEDUCTION_NEW,
-  REBATE_87A_OLD_LIMIT, REBATE_87A_OLD_MAX,
-  REBATE_87A_NEW_LIMIT, REBATE_87A_NEW_MAX,
+  TAX_SLABS_OLD,
+  TAX_SLABS_NEW,
+  STANDARD_DEDUCTION_OLD,
+  STANDARD_DEDUCTION_NEW,
+  REBATE_87A_OLD_LIMIT,
+  REBATE_87A_OLD_MAX,
+  REBATE_87A_NEW_LIMIT,
+  REBATE_87A_NEW_MAX,
   MARGINAL_RELIEF_THRESHOLD_NEW,
-  SURCHARGE_SLABS, SURCHARGE_CAP_NEW_REGIME, CESS_RATE,
-  SECTION_80C_LIMIT, SECTION_80CCD_1B_LIMIT,
-  PF_EMPLOYEE_RATE, PF_WAGE_CEILING,
-  TaxRegime, TaxComputation, TaxDeduction, TaxExemption,
+  SURCHARGE_SLABS,
+  SURCHARGE_CAP_NEW_REGIME,
+  CESS_RATE,
+  SECTION_80C_LIMIT,
+  SECTION_80CCD_1B_LIMIT,
+  PF_EMPLOYEE_RATE,
+  PF_WAGE_CEILING,
+  TaxRegime,
+  TaxComputation,
+  TaxDeduction,
+  TaxExemption,
 } from "@emp-payroll/shared";
 
 interface TaxInput {
@@ -28,14 +39,65 @@ interface TaxInput {
   employeePfAnnual: number;
   monthsWorked: number; // months remaining in FY
   taxAlreadyPaid: number;
+  // #1657 — PAN of the employee. When missing/blank, Section 206AA of the
+  // Indian Income-Tax Act applies: TDS is the higher of 20% or the
+  // applicable rate. We apply 20% flat on annual gross since that
+  // dominates the slab-rate result for almost all earners and is the
+  // documented compliance default.
+  panNumber?: string | null;
 }
+
+// 206AA flat rate when PAN is unavailable. Section 206AA(1)(iii).
+const SECTION_206AA_FLAT_RATE = 0.2;
 
 export function computeIncomeTax(input: TaxInput): TaxComputation {
   const {
-    regime, annualGross, basicAnnual, hraAnnual,
-    rentPaidAnnual, isMetroCity, declarations,
-    employeePfAnnual, monthsWorked, taxAlreadyPaid,
+    regime,
+    annualGross,
+    basicAnnual,
+    hraAnnual,
+    rentPaidAnnual,
+    isMetroCity,
+    declarations,
+    employeePfAnnual,
+    monthsWorked,
+    taxAlreadyPaid,
+    panNumber,
   } = input;
+
+  // -----------------------------------------------------------------------
+  // Section 206AA short-circuit — no PAN, flat 20% on annual gross.
+  // Returning early here keeps the slab/exemption/cess pipeline below
+  // unchanged for the regular case.
+  // -----------------------------------------------------------------------
+  const panMissing = !panNumber || panNumber.trim() === "";
+  if (panMissing) {
+    const totalTax = Math.round(annualGross * SECTION_206AA_FLAT_RATE);
+    const remainingTax = Math.max(0, totalTax - taxAlreadyPaid);
+    const remainingMonths = Math.max(1, monthsWorked);
+    const monthlyTds = Math.round(remainingTax / remainingMonths);
+    return {
+      id: `${input.employeeId}-${input.financialYear}`,
+      employeeId: input.employeeId,
+      financialYear: input.financialYear,
+      regime,
+      grossIncome: annualGross,
+      exemptions: [],
+      totalExemptions: 0,
+      deductions: [],
+      totalDeductions: 0,
+      taxableIncome: annualGross,
+      taxOnIncome: totalTax,
+      surcharge: 0,
+      healthAndEducationCess: 0,
+      totalTax,
+      taxAlreadyPaid,
+      remainingTax,
+      monthlyTds,
+      computedAt: new Date(),
+      panMissing206AA: true,
+    } as TaxComputation;
+  }
 
   let grossIncome = annualGross;
   const exemptions: TaxExemption[] = [];
@@ -55,10 +117,14 @@ export function computeIncomeTax(input: TaxInput): TaxComputation {
       const hraExempt = Math.min(
         hraAnnual,
         rentPaidAnnual - 0.1 * basicAnnual,
-        (isMetroCity ? 0.5 : 0.4) * basicAnnual
+        (isMetroCity ? 0.5 : 0.4) * basicAnnual,
       );
       if (hraExempt > 0) {
-        exemptions.push({ code: "HRA", description: "HRA exemption", amount: Math.round(hraExempt) });
+        exemptions.push({
+          code: "HRA",
+          description: "HRA exemption",
+          amount: Math.round(hraExempt),
+        });
       }
     }
 
@@ -139,7 +205,11 @@ export function computeIncomeTax(input: TaxInput): TaxComputation {
   }
 
   // Marginal relief for new regime (income between 12L and 12.75L)
-  if (regime === TaxRegime.NEW && taxableIncome > REBATE_87A_NEW_LIMIT && taxableIncome <= MARGINAL_RELIEF_THRESHOLD_NEW) {
+  if (
+    regime === TaxRegime.NEW &&
+    taxableIncome > REBATE_87A_NEW_LIMIT &&
+    taxableIncome <= MARGINAL_RELIEF_THRESHOLD_NEW
+  ) {
     const excessIncome = taxableIncome - REBATE_87A_NEW_LIMIT;
     if (taxOnIncome > excessIncome) {
       taxOnIncome = excessIncome;
@@ -152,19 +222,19 @@ export function computeIncomeTax(input: TaxInput): TaxComputation {
   let surcharge = 0;
   for (const slab of SURCHARGE_SLABS) {
     if (taxableIncome >= slab.min && taxableIncome <= slab.max) {
-      surcharge = Math.round(taxOnIncome * slab.rate / 100);
+      surcharge = Math.round((taxOnIncome * slab.rate) / 100);
       break;
     }
   }
   // Cap surcharge for new regime
   if (regime === TaxRegime.NEW) {
-    surcharge = Math.min(surcharge, Math.round(taxOnIncome * SURCHARGE_CAP_NEW_REGIME / 100));
+    surcharge = Math.min(surcharge, Math.round((taxOnIncome * SURCHARGE_CAP_NEW_REGIME) / 100));
   }
 
   // -----------------------------------------------------------------------
   // Step 8: Health & Education Cess
   // -----------------------------------------------------------------------
-  const cess = Math.round((taxOnIncome + surcharge) * CESS_RATE / 100);
+  const cess = Math.round(((taxOnIncome + surcharge) * CESS_RATE) / 100);
 
   // -----------------------------------------------------------------------
   // Step 9: Total Tax and Monthly TDS
@@ -196,14 +266,18 @@ export function computeIncomeTax(input: TaxInput): TaxComputation {
   };
 }
 
-function computeSlabTax(income: number, slabs: readonly { min: number; max: number; rate: number }[]): number {
+function computeSlabTax(
+  income: number,
+  slabs: readonly { min: number; max: number; rate: number }[],
+): number {
   let tax = 0;
   let remaining = income;
 
   for (const slab of slabs) {
     if (remaining <= 0) break;
-    const slabWidth = slab.max === Infinity ? remaining : Math.min(remaining, slab.max - slab.min + 1);
-    tax += Math.round(slabWidth * slab.rate / 100);
+    const slabWidth =
+      slab.max === Infinity ? remaining : Math.min(remaining, slab.max - slab.min + 1);
+    tax += Math.round((slabWidth * slab.rate) / 100);
     remaining -= slabWidth;
   }
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -310,6 +310,11 @@ export interface TaxComputation {
   remainingTax: number;
   monthlyTds: number;
   computedAt: Date;
+  // Set to true when the employee has no PAN on record and the engine
+  // applied the Section 206AA flat 20% short-circuit instead of the
+  // regular slab calculation. Lets the UI surface a "no PAN — higher
+  // TDS until you submit yours" warning on payslips and the tax page.
+  panMissing206AA?: boolean;
 }
 
 export interface TaxExemption {


### PR DESCRIPTION
## Summary

PR11.2a — addresses EmpCloud/EmpCloud#1656 and #1657. Builds on the data cleanup migration in #276 (PR11.1).

## What this changes (5 layers, one PR)

**1. Migration 026** — adds a STORED GENERATED `pan_number` column on `employee_payroll_profiles`, kept in lockstep with `tax_info.pan` by the database engine, plus a `UNIQUE(empcloud_org_id, pan_number)` index. App code keeps writing to `tax_info`; the generated column updates automatically. MySQL allows multiple NULLs in a UNIQUE index, so missing-PAN employees do not collide.

**2. Server validators** — `createEmployeeSchema` and the bulk-salary CSV both reject malformed PAN at write time via the regex `/^[A-Z]{5}[0-9]{4}[A-Z]$/`. Empty / unset PAN is allowed (the tax engine handles it via Section 206AA).

**3. emp_code validator** — permissive: letters, digits, dots, dashes, underscores. Rejects whitespace and other punctuation. Matches the agreed "no letter prefix required" rule. (#1658)

**4. computeIncomeTax(panNumber)** — when PAN is missing or blank, the engine short-circuits to a flat 20% on annual gross (Section 206AA(1)(iii)) and returns with `panMissing206AA: true`. The slab/exemption pipeline below the short-circuit is unchanged for the regular case.

**5. Frontend** — EmployeeCreatePage gets `pattern` + `maxLength` + uppercase styling on the PAN input and `pattern` on Employee ID. TaxOverviewPage gets a banner + per-row "No PAN" chip when `pan_number` is missing or doesn't match the format.

## Verified locally

- Migration 026 runs cleanly; idempotent on re-run.
- INSERT with duplicate PAN in same org → `ER_DUP_ENTRY 1062 "888-BLAPH9999Z"`.
- `computeIncomeTax` with valid PAN → regular slab path, `panMissing206AA: undefined`.
- `computeIncomeTax` with null / empty / whitespace / undefined PAN → `totalTax = 0.20 × annualGross`, `panMissing206AA: true`.
- TypeScript build / typecheck clean across shared / server / client.

## What this PR does NOT do

- Does not enforce `emp_code` uniqueness at the DB level — that lives in EmpCloud's `users` table and ships in a separate PR (PR11.2b).
- Does not touch the calculation engine's gross-zero / attendance-zero bugs — those are PR11.4.

## Test plan

- [ ] Migrate a fresh tenant → new column + unique index appear; no errors.
- [ ] Try to create two employees with same PAN in same org via API → second create returns 409.
- [ ] Try to create an employee with PAN "abc1" or "xgfx234bh" via API → 400 with clear message.
- [ ] Run payroll for an employee with no PAN → payslip shows TDS at 20% × annual gross.
- [ ] Run payroll for an employee with a valid PAN → unchanged from previous behavior.
- [ ] /tax page shows banner + chip for any missing-PAN employees.
