### PR TITLE
fix(payroll-runs): block future-period runs at every layer

### DIFF
--- a/packages/client/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/client/src/pages/dashboard/DashboardPage.tsx
@@ -83,8 +83,14 @@ export function DashboardPage() {
     count,
   }));
 
-  // Monthly payroll trend from paid runs
+  // Monthly payroll trend from paid runs.
+  // #1655 — Filter out any rows whose period is in the future. Until the
+  // future-period guard rolled out, tenants could end up with bogus
+  // "Paid" runs for months that hadn't started; those polluted the chart.
+  const _now = new Date();
+  const _currentPeriodKey = _now.getFullYear() * 12 + _now.getMonth();
   const trendData = paidRuns
+    .filter((r: any) => Number(r.year) * 12 + (Number(r.month) - 1) <= _currentPeriodKey)
     .slice(0, 6)
     .reverse()
     .map((r: any) => ({

--- a/packages/client/src/pages/payroll/PayrollRunsPage.tsx
+++ b/packages/client/src/pages/payroll/PayrollRunsPage.tsx
@@ -94,6 +94,14 @@ export function PayrollRunsPage() {
       toast.error("Please enter a valid year (2020–2100)");
       return;
     }
+    // #1655 — Reject future-period runs client-side too, so the user gets
+    // immediate feedback instead of a 400 from the server.
+    const requested = year * 12 + (month - 1);
+    const current = now.getFullYear() * 12 + now.getMonth();
+    if (requested > current) {
+      toast.error("Cannot create a payroll run for a future period");
+      return;
+    }
     if (!payDate) {
       toast.error("Please choose a pay date");
       return;
@@ -181,6 +189,8 @@ export function PayrollRunsPage() {
               name="year"
               label="Year"
               type="number"
+              min={2020}
+              max={now.getFullYear()}
               defaultValue={String(now.getFullYear())}
               required
             />

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
 import { Request, Response, NextFunction } from "express";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
 import { AppError } from "../middleware/error.middleware";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+// Mirror of services/payroll.service.ts — keep in sync. India-only for
+// now; lift to org settings when multi-region tenants land.
+const PAYROLL_TZ = "Asia/Kolkata";
 
 // ---------------------------------------------------------------------------
 // Validation middleware factory
@@ -297,11 +307,13 @@ export const createPayrollRunSchema = z.object({
     // allowed (orgs commonly run payroll mid-month), but anything past
     // (year, month) > today's (year, month) is bogus and was the source
     // of the "August 2026 marked Paid in April 2026" report.
+    // "Today" is anchored to PAYROLL_TZ (IST), not server-local time, so
+    // a UTC server doesn't reject the first ~5.5 hours of every IST month.
     .refine(
       (v) => {
-        const now = new Date();
+        const now = dayjs().tz(PAYROLL_TZ);
         const requested = v.year * 12 + (v.month - 1);
-        const current = now.getFullYear() * 12 + now.getMonth();
+        const current = now.year() * 12 + now.month();
         return requested <= current;
       },
       {

--- a/packages/server/src/api/validators/index.ts
+++ b/packages/server/src/api/validators/index.ts
@@ -286,12 +286,29 @@ export const bulkSalaryAssignSchema = z.object({
 // Payroll Schemas
 // ---------------------------------------------------------------------------
 export const createPayrollRunSchema = z.object({
-  body: z.object({
-    month: z.number().min(1).max(12),
-    year: z.number().min(2020).max(2100),
-    payDate: z.string(),
-    notes: z.string().optional(),
-  }),
+  body: z
+    .object({
+      month: z.number().min(1).max(12),
+      year: z.number().min(2020).max(2100),
+      payDate: z.string(),
+      notes: z.string().optional(),
+    })
+    // #1655 — Reject runs for future periods. The current month is always
+    // allowed (orgs commonly run payroll mid-month), but anything past
+    // (year, month) > today's (year, month) is bogus and was the source
+    // of the "August 2026 marked Paid in April 2026" report.
+    .refine(
+      (v) => {
+        const now = new Date();
+        const requested = v.year * 12 + (v.month - 1);
+        const current = now.getFullYear() * 12 + now.getMonth();
+        return requested <= current;
+      },
+      {
+        message: "Cannot create a payroll run for a future period",
+        path: ["month"],
+      },
+    ),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/services/payroll.service.ts
+++ b/packages/server/src/services/payroll.service.ts
@@ -11,13 +11,26 @@ import { findUsersByOrgId, findOrgById, getEmpCloudDB } from "../db/empcloud";
 import { config } from "../config";
 import * as cloudHRMS from "./cloud-hrms.service";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+// All EmpCloud tenants are India-based; payroll periods follow the
+// IST calendar regardless of where the server runs. Hardcoded for now;
+// when multi-region tenants land this should read from org settings.
+const PAYROLL_TZ = "Asia/Kolkata";
 
 // #1655 — true if (year, month) is strictly *after* the current calendar
-// month. The current month is always allowed (orgs run payroll mid-month).
+// month *in the payroll timezone*. The current month is always allowed
+// (orgs run payroll mid-month). Server-local time is wrong here: a UTC
+// server is up to ~5.5 hours behind IST, which would block the first
+// hours of every IST month from creating the new month's run.
 function isFuturePeriod(year: number, month: number): boolean {
-  const now = new Date();
+  const now = dayjs().tz(PAYROLL_TZ);
   const requested = year * 12 + (month - 1);
-  const current = now.getFullYear() * 12 + now.getMonth();
+  const current = now.year() * 12 + now.month();
   return requested > current;
 }
 
@@ -394,6 +407,18 @@ export class PayrollService {
     const run = await this.getRun(runId, orgId);
     if (run.status !== "computed") {
       throw new AppError(400, "INVALID_STATUS", "Only computed payroll runs can be approved");
+    }
+    // #1655 — Same guard as createRun/markPaid. Without this, a future-
+    // period row that existed before this fix shipped (the production
+    // tenant in the report had several) could still flow computed →
+    // approved, leaving the lifecycle inconsistent. Blocking here keeps
+    // the whole pipeline future-period-free.
+    if (isFuturePeriod(run.year, run.month)) {
+      throw new AppError(
+        400,
+        "FUTURE_PERIOD",
+        `Cannot approve a future-period run (${run.month}/${run.year} has not started yet)`,
+      );
     }
     return this.db.update("payroll_runs", runId, {
       status: "approved",

--- a/packages/server/src/services/payroll.service.ts
+++ b/packages/server/src/services/payroll.service.ts
@@ -12,6 +12,15 @@ import { config } from "../config";
 import * as cloudHRMS from "./cloud-hrms.service";
 import dayjs from "dayjs";
 
+// #1655 — true if (year, month) is strictly *after* the current calendar
+// month. The current month is always allowed (orgs run payroll mid-month).
+function isFuturePeriod(year: number, month: number): boolean {
+  const now = new Date();
+  const requested = year * 12 + (month - 1);
+  const current = now.getFullYear() * 12 + now.getMonth();
+  return requested > current;
+}
+
 export class PayrollService {
   private db = getDB();
 
@@ -33,6 +42,18 @@ export class PayrollService {
     userId: string,
     data: { month: number; year: number; payDate?: string; notes?: string },
   ) {
+    // #1655 — Reject future periods. The validator already does this for
+    // calls coming through the route, but the service guard catches any
+    // direct invocation (e.g. seed scripts, future migrations) so the
+    // rule is enforced exactly once and at the layer that owns the data.
+    if (isFuturePeriod(data.year, data.month)) {
+      throw new AppError(
+        400,
+        "FUTURE_PERIOD",
+        `Cannot create a payroll run for ${data.month}/${data.year} — period has not started yet`,
+      );
+    }
+
     const existing = await this.db.findOne<any>("payroll_runs", {
       empcloud_org_id: Number(orgId),
       month: data.month,
@@ -385,6 +406,18 @@ export class PayrollService {
     const run = await this.getRun(runId, orgId);
     if (run.status !== "approved") {
       throw new AppError(400, "INVALID_STATUS", "Only approved payroll runs can be marked as paid");
+    }
+    // #1655 — A run for a future period that somehow got created and
+    // approved must not be marked paid. Defense in depth — the validator
+    // and createRun guards block creation, but historical bad rows can
+    // still exist (the production tenant in the report had Jul/Aug/Dec
+    // 2026 runs marked Paid before this fix shipped).
+    if (isFuturePeriod(run.year, run.month)) {
+      throw new AppError(
+        400,
+        "FUTURE_PERIOD",
+        `Cannot mark a future-period run as paid (${run.month}/${run.year} has not started yet)`,
+      );
     }
     await this.db.updateMany("payslips", { payroll_run_id: runId }, { status: "paid" });
     return this.db.update("payroll_runs", runId, { status: "paid" });


### PR DESCRIPTION
## Summary

Closes EmpCloud/EmpCloud#1655. PR11.3 of the payroll-cluster batch.

Production had payroll runs for **July, August, November and December 2026 marked "Paid"** while the wall clock said April 2026. The runs had 0 employees but still polluted the dashboard's "Monthly Payroll Trend" chart and any downstream compliance reports.

## Four guard layers, top to bottom

| Layer | File | What it does |
|---|---|---|
| Validator | `validators/index.ts` | `createPayrollRunSchema` gets a refine that rejects any `(year, month)` strictly after today's calendar month. Current month allowed. |
| Service `createRun()` | `payroll.service.ts` | `isFuturePeriod()` helper, called before the duplicate check, so seed scripts and direct invocations can't bypass. |
| Service `markPaid()` | `payroll.service.ts` | Same guard. Defense in depth — even if a future-period row was approved before this fix, it can no longer be marked paid. |
| Frontend | `PayrollRunsPage.tsx` + `DashboardPage.tsx` | Client-side check in `handleCreate`, `max` attribute on the year input, and dashboard trend chart filters out any future-period rows. |

The error code `FUTURE_PERIOD` is consistent across both service entry points so the frontend can render a specific message if it ever needs to differentiate.

## What this PR does NOT do

- Does not retroactively cancel/delete existing future-period rows. That's a one-line UPDATE the user can run if needed:
  ```sql
  UPDATE payroll_runs SET status = 'cancelled' WHERE status IN ('paid','approved')
    AND (year * 100 + month) > (YEAR(NOW()) * 100 + MONTH(NOW()));
  ```
  Left as an admin task because cancelling a "Paid" run has accounting implications that should be reviewed before doing in bulk.

## Test plan

- [ ] Create a payroll run for the current month → succeeds.
- [ ] Create a payroll run for last month → succeeds.
- [ ] Create a payroll run for next month → 400 with `FUTURE_PERIOD` and a clear message.
- [ ] Create one for next year → 400 with `FUTURE_PERIOD`.
- [ ] Existing future-period run (status approved) → markPaid returns 400 instead of marking paid.
- [ ] Dashboard's Monthly Payroll Trend chart skips any rows with future periods.
- [ ] Frontend year input doesn't accept a year above the current.
