### PR TITLE
fix: round of issue fixes — dashboard / reimbursements / loans / leaves / nav

### DIFF
--- a/packages/client/src/components/layout/Sidebar.tsx
+++ b/packages/client/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router-dom";
+import { NavLink, useLocation } from "react-router-dom";
 import { getUser, logout } from "@/api/auth";
 import { cn } from "@/lib/utils";
 import {
@@ -236,11 +236,29 @@ const navItems: NavItem[] = [
 export function Sidebar() {
   const user = getUser();
   const role = (user?.role || "employee") as Role;
+  const { pathname } = useLocation();
 
   const visibleItems = navItems.filter((item) => {
     if (!item.roles) return true; // visible to all
     return item.roles.includes(role);
   });
+
+  // #315 — Pick the single nav item whose `to` is the longest prefix of the
+  // current path. Previously we used NavLink's `end` flag with auto-detection
+  // ("Employees" was force-ended because `/employees/org-chart` exists as a
+  // sibling), which made the Employees entry stop glowing as soon as the
+  // user opened any individual employee at `/employees/:id`. This computes
+  // the most specific match so detail routes still light up their parent
+  // tab while sibling routes (org-chart, etc.) keep their own highlight.
+  const activeTo = (() => {
+    let best: string | null = null;
+    for (const item of visibleItems) {
+      if (pathname === item.to || pathname.startsWith(item.to + "/")) {
+        if (!best || item.to.length > best.length) best = item.to;
+      }
+    }
+    return best;
+  })();
 
   // Group by section
   let lastSection = "";
@@ -271,14 +289,7 @@ export function Sidebar() {
         {visibleItems.map((item) => {
           const showSection = item.section && item.section !== lastSection;
           if (item.section) lastSection = item.section;
-          // NavLink's default isActive matches any URL that starts with
-          // `to` + "/". So clicking /employees/org-chart also lit up the
-          // Employees entry ("/employees") — issue #42. Mark `end` on any
-          // item whose `to` is a prefix of another item's `to`, so the
-          // broader route only highlights on its exact match.
-          const hasMoreSpecificSibling = visibleItems.some(
-            (other) => other.to !== item.to && other.to.startsWith(item.to + "/"),
-          );
+          const isActive = activeTo === item.to;
           return (
             <div key={item.to}>
               {showSection && (
@@ -288,15 +299,13 @@ export function Sidebar() {
               )}
               <NavLink
                 to={item.to}
-                end={item.to === "/my" || hasMoreSpecificSibling}
-                className={({ isActive }) =>
-                  cn(
-                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                    isActive
-                      ? "bg-brand-50 text-brand-700 dark:bg-brand-950 dark:text-brand-400"
-                      : "text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-white",
-                  )
-                }
+                end
+                className={cn(
+                  "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-brand-50 text-brand-700 dark:bg-brand-950 dark:text-brand-400"
+                    : "text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-white",
+                )}
               >
                 <item.icon className="h-4.5 w-4.5 shrink-0" />
                 {item.label}

--- a/packages/client/src/pages/announcements/AnnouncementsPage.tsx
+++ b/packages/client/src/pages/announcements/AnnouncementsPage.tsx
@@ -91,7 +91,10 @@ export function AnnouncementsPage() {
               <CardContent className="py-5">
                 <div className="flex-1">
                   <div className="mb-1 flex flex-wrap items-center gap-2">
-                    {a.is_pinned && <Pin className="text-brand-600 h-4 w-4" />}
+                    {/* #297 — `is_pinned` arrives as MySQL TINYINT (0/1);
+                        bare `a.is_pinned && <Pin/>` renders the literal "0"
+                        on every unpinned card. Coerce to boolean. */}
+                    {!!a.is_pinned && <Pin className="text-brand-600 h-4 w-4" />}
                     <h3 className="text-lg font-semibold text-gray-900">{a.title}</h3>
                     <span
                       className={`rounded-full px-2 py-0.5 text-xs font-medium ${priorityColors[a.priority] || priorityColors.normal}`}

--- a/packages/client/src/pages/benefits/BenefitsPage.tsx
+++ b/packages/client/src/pages/benefits/BenefitsPage.tsx
@@ -229,11 +229,32 @@ export function BenefitsPage() {
     },
   ];
 
+  // #312 — enrollments only showed `#<id>`, no name. Build a quick lookup off
+  // the already-loaded employees list and resolve names at render time.
+  const employeeById: Record<string, any> = {};
+  for (const e of employees) {
+    if (e.id != null) employeeById[String(e.id)] = e;
+    if (e.empcloud_user_id != null) employeeById[String(e.empcloud_user_id)] = e;
+  }
+
   const enrollColumns = [
     {
       key: "employee",
-      header: "Employee ID",
-      render: (r: any) => <span className="font-medium">#{r.empcloud_user_id}</span>,
+      header: "Employee",
+      render: (r: any) => {
+        const emp = employeeById[String(r.empcloud_user_id)];
+        const fullName = emp
+          ? `${emp.first_name || emp.firstName || ""} ${emp.last_name || emp.lastName || ""}`.trim()
+          : "";
+        return (
+          <div>
+            <p className="font-medium text-gray-900">{fullName || `User #${r.empcloud_user_id}`}</p>
+            {(emp?.employee_code || emp?.emp_code) && (
+              <p className="text-xs text-gray-500">{emp.employee_code || emp.emp_code}</p>
+            )}
+          </div>
+        );
+      },
     },
     {
       key: "plan",

--- a/packages/client/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/client/src/pages/dashboard/DashboardPage.tsx
@@ -193,12 +193,30 @@ export function DashboardPage() {
           subtitle={lastRun ? `${MONTHS[lastRun.month]} ${lastRun.year}` : "No payroll yet"}
           icon={TrendingUp}
         />
-        <StatCard
-          title="Total Deductions"
-          value={lastRun ? formatCurrency(lastRun.total_deductions) : "—"}
-          subtitle="PF + ESI + PT + TDS"
-          icon={AlertCircle}
-        />
+        {/* #314 — Card was previously inert; HR wanted it to drill into the
+            breakdown. Link to the latest run's detail page where the per-
+            component deduction split (PF / ESI / PT / TDS) is rendered. */}
+        {lastRun ? (
+          <Link
+            to={`/payroll/runs/${lastRun.id}`}
+            aria-label="View total deductions breakdown for the latest payroll run"
+          >
+            <StatCard
+              title="Total Deductions"
+              value={formatCurrency(lastRun.total_deductions)}
+              subtitle="PF + ESI + PT + TDS"
+              icon={AlertCircle}
+              className="h-full cursor-pointer"
+            />
+          </Link>
+        ) : (
+          <StatCard
+            title="Total Deductions"
+            value="—"
+            subtitle="PF + ESI + PT + TDS"
+            icon={AlertCircle}
+          />
+        )}
       </div>
 
       {/* Charts row */}
@@ -299,7 +317,13 @@ export function DashboardPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {/* #300 — Compliance card sits in a 2-col grid at lg+ so its
+                width is narrow. Forcing 4 columns on `sm` then made
+                "Provident Fund" / "Professional Tax" / "TDS (Form 24Q)"
+                push the icon and badge past the card border. Drop the
+                `sm:grid-cols-4` step and add `min-w-0 truncate` so the
+                label shrinks rather than overflowing. */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               {(
                 [
                   { label: "Provident Fund", filed: true },
@@ -313,12 +337,12 @@ export function DashboardPage() {
                   className="flex items-center gap-3 rounded-lg border border-gray-100 p-4"
                 >
                   {item.filed ? (
-                    <CheckCircle2 className="h-5 w-5 text-green-500" />
+                    <CheckCircle2 className="h-5 w-5 shrink-0 text-green-500" />
                   ) : (
-                    <XCircle className="h-5 w-5 text-red-400" />
+                    <XCircle className="h-5 w-5 shrink-0 text-red-400" />
                   )}
-                  <div>
-                    <p className="text-sm font-medium text-gray-900">{item.label}</p>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-gray-900">{item.label}</p>
                     <Badge variant={item.filed ? "approved" : "pending"}>
                       {item.filed ? "Filed" : "Pending"}
                     </Badge>

--- a/packages/client/src/pages/payroll/PayrollRunDetailPage.tsx
+++ b/packages/client/src/pages/payroll/PayrollRunDetailPage.tsx
@@ -235,7 +235,14 @@ export function PayrollRunDetailPage() {
         title={
           run.month && run.year ? `${formatMonth(run.month, run.year)} Payroll Run` : "Payroll Run"
         }
-        description={`Run ${run.code || run.id?.slice(0, 8) || ""} · ${run.status?.toUpperCase() || ""}`}
+        // #306 — surface the human-readable period (e.g. "January 2026")
+        // alongside the status; the auto-generated `code` is meaningless to
+        // HR users and the issue reporter wanted the period name shown.
+        description={
+          run.month && run.year
+            ? `${formatMonth(run.month, run.year)} · ${run.status?.toUpperCase() || ""}`
+            : `Run ${run.code || run.id?.slice(0, 8) || ""} · ${run.status?.toUpperCase() || ""}`
+        }
         actions={
           <div className="flex items-center gap-3">
             <Button variant="ghost" onClick={() => navigate("/payroll/runs")}>

--- a/packages/client/src/pages/payroll/SalaryStructuresPage.tsx
+++ b/packages/client/src/pages/payroll/SalaryStructuresPage.tsx
@@ -419,6 +419,11 @@ export function SalaryStructuresPage() {
                               : c.value
                         }
                         placeholder={c.calculationType === "balance" ? "auto" : "0"}
+                        // #316 — pre-select the contents on focus so typing
+                        // overwrites the leading 0 instead of producing "01",
+                        // "012", etc. Users were having to manually delete
+                        // the 0 before every entry.
+                        onFocus={(e) => e.currentTarget.select()}
                         onChange={(e) => {
                           const raw = e.target.value;
                           if (raw === "") {

--- a/packages/client/src/pages/reimbursements/ReimbursementsPage.tsx
+++ b/packages/client/src/pages/reimbursements/ReimbursementsPage.tsx
@@ -21,11 +21,22 @@ export function ReimbursementsPage() {
     queryFn: () => apiGet<any>("/reimbursements", filter ? { status: filter } : {}),
   });
 
+  // #301 — top stat cards are an org-wide summary; previously they were
+  // derived from `claims` which is already status-filtered server-side, so
+  // clicking "Approved" filtered the table AND zeroed the Pending / Rejected
+  // / Paid cards. Fetch the unfiltered list separately and drive the cards
+  // off it (mirrors the loans-page fix in #158).
+  const { data: allRes } = useQuery({
+    queryKey: ["reimbursements-all"],
+    queryFn: () => apiGet<any>("/reimbursements"),
+  });
+
   const claims = res?.data?.data || [];
-  const pending = claims.filter((c: any) => c.status === "pending");
-  const approved = claims.filter((c: any) => c.status === "approved");
-  const rejected = claims.filter((c: any) => c.status === "rejected");
-  const paid = claims.filter((c: any) => c.status === "paid");
+  const allClaims = allRes?.data?.data || [];
+  const pending = allClaims.filter((c: any) => c.status === "pending");
+  const approved = allClaims.filter((c: any) => c.status === "approved");
+  const rejected = allClaims.filter((c: any) => c.status === "rejected");
+  const paid = allClaims.filter((c: any) => c.status === "paid");
   const totalPending = pending.reduce((s: number, c: any) => s + Number(c.amount), 0);
   const totalApproved = approved.reduce((s: number, c: any) => s + Number(c.amount), 0);
   const totalRejected = rejected.reduce((s: number, c: any) => s + Number(c.amount), 0);
@@ -35,6 +46,7 @@ export function ReimbursementsPage() {
       await apiPost(`/reimbursements/${id}/${action}`);
       toast.success(`Claim ${action}d`);
       qc.invalidateQueries({ queryKey: ["reimbursements"] });
+      qc.invalidateQueries({ queryKey: ["reimbursements-all"] });
     } catch (err: any) {
       toast.error(err.response?.data?.error?.message || "Failed");
     }
@@ -122,7 +134,7 @@ export function ReimbursementsPage() {
           className="focus-visible:ring-brand-500 block rounded-xl transition hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2"
           aria-label="View all reimbursement claims"
         >
-          <StatCard title="Total Claims" value={String(claims.length)} icon={Receipt} />
+          <StatCard title="Total Claims" value={String(allClaims.length)} icon={Receipt} />
         </Link>
         <Link
           to="/reimbursements"

--- a/packages/client/src/pages/self-service/MyLeavesPage.tsx
+++ b/packages/client/src/pages/self-service/MyLeavesPage.tsx
@@ -72,10 +72,23 @@ export function MyLeavesPage() {
   // found" error (#26).
   const leaveTypes: Array<{ id: number | string; code: string; name: string }> =
     typesData?.data || [];
-  const leaveTypeOptions = leaveTypes.map((t) => ({
-    value: String(t.id),
-    label: t.name,
-  }));
+  // #309 — Some orgs have multiple leave_types rows that share a display
+  // name (e.g. an old "SL" left over after admin recreated "Sick Leave"),
+  // which made the dropdown show "Sick Leave" twice. Dedupe by name —
+  // keeping the first occurrence is fine for picking; the apply call uses
+  // the numeric id so we don't lose precision.
+  const seenNames = new Set<string>();
+  const leaveTypeOptions = leaveTypes
+    .filter((t) => {
+      const key = (t.name || "").trim().toLowerCase();
+      if (!key || seenNames.has(key)) return false;
+      seenNames.add(key);
+      return true;
+    })
+    .map((t) => ({
+      value: String(t.id),
+      label: t.name,
+    }));
 
   const { data: requestsData, isLoading: reqLoading } = useQuery({
     queryKey: ["my-leave-requests", filter],

--- a/packages/client/src/pages/self-service/SelfServiceDashboard.tsx
+++ b/packages/client/src/pages/self-service/SelfServiceDashboard.tsx
@@ -179,7 +179,9 @@ function AnnouncementsWidget() {
               className={`rounded-lg border p-3 ${a.is_pinned ? "border-brand-200 bg-brand-50/30" : "border-gray-100"}`}
             >
               <div className="mb-1 flex items-center gap-2">
-                {a.is_pinned && <Pin className="text-brand-600 h-3 w-3" />}
+                {/* #298 — same JSX boolean trap as #297; is_pinned is a
+                    MySQL TINYINT, so the bare && renders "0" on each card. */}
+                {!!a.is_pinned && <Pin className="text-brand-600 h-3 w-3" />}
                 <h4 className="text-sm font-semibold text-gray-900">{a.title}</h4>
                 <span
                   className={`rounded-full px-2 py-0.5 text-xs font-medium ${priorityColors[a.priority] || priorityColors.normal}`}

--- a/packages/client/src/pages/tax/TaxOverviewPage.tsx
+++ b/packages/client/src/pages/tax/TaxOverviewPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { StatCard } from "@/components/ui/StatCard";
 import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/Card";
@@ -17,6 +17,7 @@ export function TaxOverviewPage() {
   const { data: res, isLoading } = useEmployees({ limit: 1000 });
   const employees = res?.data?.data || [];
 
+  const navigate = useNavigate();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   const regimeFilter = searchParams.get("regime"); // "new" | "old" | null
@@ -157,7 +158,13 @@ export function TaxOverviewPage() {
               <Loader2 className="text-brand-600 h-6 w-6 animate-spin" />
             </div>
           ) : (
-            <DataTable columns={columns} data={taxData} />
+            <DataTable
+              columns={columns}
+              data={taxData}
+              // #299 — make rows clickable so HR can drill into the employee
+              // profile (and edit tax_info / PAN if they need to).
+              onRowClick={(row: any) => row.id && navigate(`/employees/${row.id}`)}
+            />
           )}
         </CardContent>
       </Card>

--- a/packages/server/src/api/middleware/auth.middleware.ts
+++ b/packages/server/src/api/middleware/auth.middleware.ts
@@ -52,13 +52,19 @@ export function authorize(...roles: AuthPayload["role"][]) {
     if (!req.user) {
       return next(new AppError(401, "UNAUTHORIZED", "Not authenticated"));
     }
-    // org_admin is a superset of hr_admin — grant access whenever any admin role is allowed
+    // org_admin / super_admin are supersets of hr_admin — grant access whenever
+    // any admin role is allowed. (#313, #302 — admin users with role
+    // `super_admin` were getting 403 on reimbursement approve/reject because
+    // the middleware only escalated for org_admin.)
     const effectiveRoles = [...roles];
     if (
       (roles.includes("hr_admin") || roles.includes("hr_manager")) &&
       !roles.includes("org_admin")
     ) {
       effectiveRoles.push("org_admin");
+    }
+    if (roles.length > 0 && !effectiveRoles.includes("super_admin")) {
+      effectiveRoles.push("super_admin");
     }
     if (effectiveRoles.length > 0 && !effectiveRoles.includes(req.user.role)) {
       return next(

--- a/packages/server/src/services/attendance.service.ts
+++ b/packages/server/src/services/attendance.service.ts
@@ -71,32 +71,66 @@ export class AttendanceService {
       .groupBy("ar.user_id", "u.first_name", "u.last_name", "u.emp_code");
 
     if (records.length === 0) {
-      // No attendance records in EmpCloud for this month — return all org users with zero attendance
+      // No attendance records in EmpCloud for this month. #308 — but the
+      // local `attendance_summaries` table may have rows from "Mark All
+      // Present" writes; surface those before falling back to all-zero.
       const users = await empcloudDb("users")
         .where({ organization_id: orgIdNum, status: 1 })
         .whereNot("role", "super_admin")
         .select("id as empcloud_user_id", "first_name", "last_name", "emp_code");
 
-      const zeroData = users.map((u: any) => ({
-        ...u,
-        month,
-        year,
-        total_days: totalWorkingDays,
-        present_days: 0,
-        half_days: 0,
-        absent_days: 0,
-        leave_days: 0,
-        overtime_hours: 0,
-        paid_leave: 0,
-        unpaid_leave: 0,
-        lop_days: 0,
-        holidays: 0,
-        weekoffs: 0,
-        overtime_rate: 0,
-        overtime_amount: 0,
-      }));
+      const localOverrides = await this.db.findMany<any>("attendance_summaries", {
+        filters: { month, year },
+        limit: 10000,
+      });
+      const localMap: Record<number, any> = {};
+      for (const r of localOverrides.data) {
+        if (r.empcloud_user_id != null) localMap[Number(r.empcloud_user_id)] = r;
+      }
 
-      return { data: zeroData, total: zeroData.length, page: 1, limit: 1000, totalPages: 1 };
+      const data = users.map((u: any) => {
+        const local = localMap[u.empcloud_user_id];
+        if (local) {
+          return {
+            ...u,
+            month,
+            year,
+            total_days: Number(local.total_days) || totalWorkingDays,
+            present_days: Number(local.present_days) || 0,
+            half_days: Number(local.half_days) || 0,
+            absent_days: Number(local.absent_days) || 0,
+            leave_days: Number(local.paid_leave || 0) + Number(local.unpaid_leave || 0),
+            overtime_hours: Number(local.overtime_hours) || 0,
+            paid_leave: Number(local.paid_leave) || 0,
+            unpaid_leave: Number(local.unpaid_leave) || 0,
+            lop_days: Number(local.lop_days) || 0,
+            holidays: Number(local.holidays) || 0,
+            weekoffs: Number(local.weekoffs) || 0,
+            overtime_rate: Number(local.overtime_rate) || 0,
+            overtime_amount: Number(local.overtime_amount) || 0,
+          };
+        }
+        return {
+          ...u,
+          month,
+          year,
+          total_days: totalWorkingDays,
+          present_days: 0,
+          half_days: 0,
+          absent_days: 0,
+          leave_days: 0,
+          overtime_hours: 0,
+          paid_leave: 0,
+          unpaid_leave: 0,
+          lop_days: 0,
+          holidays: 0,
+          weekoffs: 0,
+          overtime_rate: 0,
+          overtime_amount: 0,
+        };
+      });
+
+      return { data, total: data.length, page: 1, limit: 1000, totalPages: 1 };
     }
 
     // Get approved leaves from EmpCloud for the same period
@@ -134,6 +168,21 @@ export class AttendanceService {
     const recordMap: Record<number, any> = {};
     for (const r of records) recordMap[r.empcloud_user_id] = r;
 
+    // #308 — Mark All Present writes to the local `attendance_summaries`
+    // table (importRecords), but bulkSummary previously only read from
+    // EmpCloud's `attendance_records`. The result was a "Marked successful"
+    // toast followed by an unchanged dashboard. Pull the local override
+    // rows for this period and use them as a fallback for users who
+    // have no EmpCloud rows yet.
+    const localOverrides = await this.db.findMany<any>("attendance_summaries", {
+      filters: { month, year },
+      limit: 10000,
+    });
+    const localMap: Record<number, any> = {};
+    for (const r of localOverrides.data) {
+      if (r.empcloud_user_id != null) localMap[Number(r.empcloud_user_id)] = r;
+    }
+
     const enriched = allUsers.map((u: any) => {
       const r = recordMap[u.empcloud_user_id];
       const userLeave = leaveMap[u.empcloud_user_id] || { paid: 0, unpaid: 0 };
@@ -147,6 +196,30 @@ export class AttendanceService {
           weekoffs: 0,
           overtime_rate: 0,
           overtime_amount: 0,
+        };
+      }
+      const local = localMap[u.empcloud_user_id];
+      if (local) {
+        return {
+          empcloud_user_id: u.empcloud_user_id,
+          first_name: u.first_name,
+          last_name: u.last_name,
+          emp_code: u.emp_code,
+          month,
+          year,
+          total_days: Number(local.total_days) || totalWorkingDays,
+          present_days: Number(local.present_days) || 0,
+          half_days: Number(local.half_days) || 0,
+          absent_days: Number(local.absent_days) || 0,
+          leave_days: Number(local.paid_leave || 0) + Number(local.unpaid_leave || 0),
+          overtime_hours: Number(local.overtime_hours) || 0,
+          paid_leave: Number(local.paid_leave) || userLeave.paid,
+          unpaid_leave: Number(local.unpaid_leave) || userLeave.unpaid,
+          lop_days: Number(local.lop_days) || userLeave.unpaid,
+          holidays: Number(local.holidays) || 0,
+          weekoffs: Number(local.weekoffs) || 0,
+          overtime_rate: Number(local.overtime_rate) || 0,
+          overtime_amount: Number(local.overtime_amount) || 0,
         };
       }
       // Employee has no attendance rows this month — surface as a

--- a/packages/server/src/services/employee.service.ts
+++ b/packages/server/src/services/employee.service.ts
@@ -411,6 +411,23 @@ export class EmployeeService {
     if (data.phone !== undefined) ecUpdates.contact_number = data.phone;
     if (data.designation) ecUpdates.designation = data.designation;
     if (data.departmentId !== undefined) ecUpdates.department_id = data.departmentId;
+    // #291 — the EmployeeDetailPage edit modal sends `department` as the
+    // department NAME (its <select> options use `value: d.name`). The schema
+    // accepts that field but the service was only writing `departmentId`,
+    // so the name was passed validation and then silently dropped — the
+    // toast said "Employee updated" but the department never changed.
+    // Resolve the name to an id here so existing callers keep working.
+    if (
+      data.departmentId === undefined &&
+      typeof data.department === "string" &&
+      data.department.trim()
+    ) {
+      const dept = await db("organization_departments")
+        .where({ organization_id: empcloudOrgId })
+        .where("name", data.department.trim())
+        .first();
+      if (dept) ecUpdates.department_id = dept.id;
+    }
     if (data.locationId !== undefined) ecUpdates.location_id = data.locationId;
     if (data.reportingManagerId !== undefined)
       ecUpdates.reporting_manager_id = data.reportingManagerId;

--- a/packages/server/src/services/loan.service.ts
+++ b/packages/server/src/services/loan.service.ts
@@ -39,27 +39,33 @@ export class LoanService {
       limit: 100,
     });
 
-    // Enrich with employee names. Loans cut against the legacy employees
-    // table store the name there; loans cut after the EmpCloud integration
-    // store only empcloud_user_id (the employees row may not exist), so
-    // names have to come from the EmpCloud users table for those rows
-    // (#206 — admin saw "Unknown" for every loan).
-    const empIds = [...new Set(result.data.map((l: any) => l.employee_id).filter(Boolean))];
-    const userIds = [
-      ...new Set(
-        result.data
-          .map((l: any) => Number(l.empcloud_user_id))
-          .filter((n: any) => Number.isFinite(n) && n > 0),
-      ),
-    ];
+    // Enrich with employee names. Loans created from the new flow store the
+    // EmpCloud user id directly in `employee_id` (the payroll-side `employees`
+    // row may never exist), so we have to resolve names against BOTH:
+    //   1) the legacy payroll `employees` table (when employee_id is a UUID)
+    //   2) EmpCloud `users.id` (when employee_id is numeric, OR when an
+    //      `empcloud_user_id` column was explicitly set)
+    //
+    // #303 — every loan was rendering as "Unknown" because the create path
+    // sets `employee_id` to the EmpCloud user id and leaves `empcloud_user_id`
+    // null, so neither lookup found a match. Now we treat any numeric
+    // `employee_id` as a candidate EmpCloud user id and try both lookups.
+    const empIdsRaw = [...new Set(result.data.map((l: any) => l.employee_id).filter(Boolean))];
+    const numericEmployeeIds = empIdsRaw
+      .map((v: any) => Number(v))
+      .filter((n: any) => Number.isFinite(n) && n > 0);
+    const explicitUserIds = result.data
+      .map((l: any) => Number(l.empcloud_user_id))
+      .filter((n: any) => Number.isFinite(n) && n > 0);
+    const userIds = [...new Set([...numericEmployeeIds, ...explicitUserIds])];
 
     const empMap: Record<string, any> = {};
-    for (const eid of empIds) {
+    for (const eid of empIdsRaw) {
       const emp = await this.db.findById<any>("employees", eid as string).catch(() => null);
       if (emp) empMap[eid as string] = emp;
     }
 
-    let userMap: Record<string, any> = {};
+    const userMap: Record<string, any> = {};
     if (userIds.length > 0) {
       try {
         const ecDb = getEmpCloudDB();
@@ -78,7 +84,9 @@ export class LoanService {
       ...result,
       data: result.data.map((l: any) => {
         const emp = empMap[l.employee_id];
-        const user = l.empcloud_user_id ? userMap[String(l.empcloud_user_id)] : undefined;
+        const userByExplicit = l.empcloud_user_id ? userMap[String(l.empcloud_user_id)] : undefined;
+        const userByEmployeeId = userMap[String(l.employee_id)];
+        const user = userByExplicit || userByEmployeeId;
         const name = emp
           ? `${emp.first_name} ${emp.last_name}`
           : user
@@ -125,8 +133,18 @@ export class LoanService {
           )
         : Math.round(data.principalAmount / data.tenureMonths);
 
+    // #303 — when the supplied employeeId is purely numeric it's an EmpCloud
+    // user id (the new dropdown sets `value={user.id}`), so also stamp
+    // empcloud_user_id so the list query can do a clean join even after the
+    // row is created. Older UUID-style ids (legacy employees table) leave it
+    // null and fall back to the employees-table lookup.
+    const numericEmployeeId = Number(data.employeeId);
+    const empcloudUserId =
+      Number.isFinite(numericEmployeeId) && numericEmployeeId > 0 ? numericEmployeeId : null;
+
     return this.db.create("loans", {
       employee_id: data.employeeId,
+      empcloud_user_id: empcloudUserId,
       org_id: orgId,
       type: data.type,
       description: data.description,

--- a/packages/server/src/services/reimbursement.service.ts
+++ b/packages/server/src/services/reimbursement.service.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { getDB } from "../db/adapters";
+import { getEmpCloudDB } from "../db/empcloud";
 import { AppError } from "../api/middleware/error.middleware";
 
 // #38 — Reject negative or non-finite amounts server-side. Using Zod here
@@ -61,12 +62,46 @@ export class ReimbursementService {
       limit: 100,
     });
 
+    // #290 — `employee_payroll_profiles` has NO first_name / last_name columns
+    // (it stores payroll-specific data only — bank, tax, PF/ESI). When the
+    // matched row was a profile rather than a legacy employees row, the
+    // template literal `${row.first_name} ${row.last_name}` rendered the
+    // literal string "undefined undefined" instead of the employee's name.
+    // Resolve names from EmpCloud users for any row that doesn't come with
+    // first_name populated.
+    const userIds = new Set<number>();
+    for (const r of result.data) {
+      const row = empMap[r.employee_id];
+      const ecUid = Number(row?.empcloud_user_id ?? r.empcloud_user_id);
+      if (Number.isFinite(ecUid) && ecUid > 0 && !row?.first_name) {
+        userIds.add(ecUid);
+      }
+    }
+    const userMap: Record<string, { first_name: string; last_name: string; emp_code?: string }> =
+      {};
+    if (userIds.size > 0) {
+      try {
+        const ecDb = getEmpCloudDB();
+        const users = await ecDb("users")
+          .whereIn("id", Array.from(userIds))
+          .select("id", "first_name", "last_name", "emp_code");
+        for (const u of users) userMap[String(u.id)] = u;
+      } catch {
+        // EmpCloud unreachable — names will fall through to "Unknown".
+      }
+    }
+
     const enriched = result.data.map((r: any) => {
       const row = empMap[r.employee_id];
+      const ecUid = String(row?.empcloud_user_id ?? r.empcloud_user_id ?? "");
+      const ecUser = userMap[ecUid];
+      const first = row?.first_name ?? ecUser?.first_name;
+      const last = row?.last_name ?? ecUser?.last_name;
+      const employee_name = first || last ? [first, last].filter(Boolean).join(" ") : "Unknown";
       return {
         ...r,
-        employee_name: row ? `${row.first_name} ${row.last_name}` : "Unknown",
-        employee_code: row?.employee_code || "",
+        employee_name,
+        employee_code: row?.employee_code || ecUser?.emp_code || "",
       };
     });
 


### PR DESCRIPTION
## Summary

Addresses 14 of the open bug reports against the admin dashboard, the reimbursement / loan listings, the attendance import flow, and several small UX traps. No schema changes; one server-side role middleware tweak, the rest are client-only or service-layer joins. All three packages (server / shared / client) build clean.

Closes #290, closes #291, closes #297, closes #298, closes #299, closes #300, closes #301, closes #302, closes #303, closes #306, closes #308, closes #309, closes #312, closes #313, closes #314, closes #315, closes #316.

Also investigated but commented separately for more info: #287, #307, #310, #304, #305, #256, #271, #272, #274.

## Highlights

### Cards / dashboard
- **#297 / #298** Announcement cards rendered a literal "0" because `{a.is_pinned && <Pin/>}` pulled the MySQL TINYINT directly into JSX — classic boolean trap. Coerce with `!!`.
- **#300** Compliance Status grid was forcing 4 columns inside a 2-col parent at lg+, which spilled "Provident Fund" / "TDS (Form 24Q)" past the card border. Drop to 1/2 columns and add `min-w-0 truncate`.
- **#314** Total Deductions card on the admin dashboard is now a `<Link>` to the latest payroll run's detail page, where the per-component split (PF / ESI / PT / TDS) is rendered.
- **#306** Payroll Run detail header now shows "January 2026 · COMPUTED" instead of "Run ABC123 · COMPUTED".
- **#316** Salary Structures component value field selects its content on focus, so typing overwrites the leading 0.

### Listing tables (employee-name resolution)
- **#303** Loans list resolved names by `employee_id` against the legacy `employees` table only; new flows store the EmpCloud user id directly in `employee_id`. Treat numeric `employee_id` as a candidate EmpCloud user id during enrichment, and stamp `empcloud_user_id` on create going forward.
- **#290** Reimbursements showed `"undefined undefined"` when the matched row came from `employee_payroll_profiles` (no first_name / last_name columns there). Resolve names from EmpCloud users when the profile lookup doesn't carry them.
- **#312** Benefits Administration enrollments now show the employee's full name + employee code; the column was previously just `#1234`.
- **#301** Reimbursements stat cards used the status-filtered list to count Pending / Approved / Rejected / Paid, so clicking one card zeroed the others. Fetch an unfiltered list separately for the stats (mirrors the loans-page fix in #158).
- **#299** Tax page rows are now clickable and navigate to the employee detail page so HR can update PAN / regime in one hop.

### Form persistence / RBAC
- **#291** Admin Employees Save Changes "succeeded" but never persisted the department: the form sends `department` as the NAME, but the service was only writing `departmentId`. Resolve the name to an id on the server when departmentId isn't supplied.
- **#313 / #302** Reimbursement approve/reject now succeed for `super_admin` users — the role-escalation in `authorize()` only added `org_admin` for `hr_admin` routes, super_admins were silently 403'd.
- **#308** "Mark All Present" wrote to the local `attendance_summaries` table but `bulkSummary` only read from EmpCloud's `attendance_records`, so the toast said "successful" while the dashboard never updated. Merge the local override rows into the bulk read.
- **#309** Apply-leave dropdown deduped against the `leave_types` list by name so re-added types (CL + CL_440 with the same display label) no longer appear twice.

### Navigation
- **#315** Sidebar "Employees" entry stopped glowing as soon as you opened any individual employee at `/employees/:id`. Switched from NavLink's auto-`end` mode to a longest-prefix match across the visible nav items, so detail routes light up their parent tab while sibling routes (org-chart, etc.) keep their own highlight.

## Test plan

- [ ] Open Announcements / Self-Service dashboard — no stray `0` on any unpinned card
- [ ] Click "Total Deductions" on admin dashboard — lands on latest payroll run detail page
- [ ] Open a payroll run — header shows e.g. "January 2026 · COMPUTED" (not the random code)
- [ ] Salary Structures: focus on a value cell with `0` in it, type — overwrites instead of producing `01`
- [ ] Loans list: every row shows a real name (no `Unknown`)
- [ ] Reimbursements list: every row shows a real name (no `undefined undefined`); clicking the Pending card filters but other cards retain their counts
- [ ] Benefits Administration: enrolled employees column shows the employee name + code
- [ ] Tax page: click an employee row → lands on `/employees/<id>`
- [ ] Compliance Status card on lg+: "TDS (Form 24Q)" stays inside its sub-card, no overflow
- [ ] Edit an employee in admin Employees: change department → save → refresh → department persists
- [ ] Reimbursement approve/reject as a super_admin user — succeeds (was 403 before)
- [ ] Attendance > Mark All Present — table updates to show present_days = totalDays
- [ ] Apply Leave dropdown for a tenant with duplicate `Sick Leave` rows — only one entry per name
- [ ] Click on `/employees/<some-id>` — sidebar Employees entry stays highlighted (was unhighlighting before)